### PR TITLE
Fix: allow 0x prefix when passing hex-encoded parameters

### DIFF
--- a/src/cli/aurora.rs
+++ b/src/cli/aurora.rs
@@ -56,8 +56,7 @@ pub async fn execute_command(
         // Command::Benchmark
         Command::Read { subcommand } => match subcommand {
             ReadCommand::GetResult { tx_hash_hex } => {
-                let tx_hash =
-                    aurora_engine_types::H256::from_slice(&hex::decode(tx_hash_hex).unwrap());
+                let tx_hash = aurora_engine_types::H256(utils::hex_to_arr(&tx_hash_hex).unwrap());
                 let outcome = client.get_transaction_outcome(tx_hash).await?;
                 println!("{outcome:?}");
             }
@@ -65,9 +64,9 @@ pub async fn execute_command(
         Command::Write { subcommand } => match subcommand {
             WriteCommand::Deploy { input_data_hex } => {
                 let source_private_key_hex = config.get_evm_secret_key();
-                let sk_bytes = utils::hex_to_arr32(source_private_key_hex)?;
+                let sk_bytes = utils::hex_to_arr(source_private_key_hex)?;
                 let sk = libsecp256k1::SecretKey::parse(&sk_bytes).unwrap();
-                let input = hex::decode(input_data_hex)?;
+                let input = utils::hex_to_vec(&input_data_hex)?;
                 send_transaction(client, &sk, None, Wei::zero(), input).await?;
             }
             WriteCommand::Transfer {
@@ -75,9 +74,9 @@ pub async fn execute_command(
                 amount,
             } => {
                 let source_private_key_hex = config.get_evm_secret_key();
-                let sk_bytes = utils::hex_to_arr32(source_private_key_hex)?;
+                let sk_bytes = utils::hex_to_arr(source_private_key_hex)?;
                 let sk = libsecp256k1::SecretKey::parse(&sk_bytes).unwrap();
-                let target = Address::decode(&target_addr_hex).unwrap();
+                let target = utils::hex_to_address(&target_addr_hex)?;
                 let amount = Wei::new(U256::from_dec_str(&amount).unwrap());
                 send_transaction(client, &sk, Some(target), amount, Vec::new()).await?;
             }
@@ -87,13 +86,13 @@ pub async fn execute_command(
                 input_data_hex,
             } => {
                 let source_private_key_hex = config.get_evm_secret_key();
-                let sk_bytes = utils::hex_to_arr32(source_private_key_hex)?;
+                let sk_bytes = utils::hex_to_arr(source_private_key_hex)?;
                 let sk = libsecp256k1::SecretKey::parse(&sk_bytes).unwrap();
-                let target = Address::decode(&target_addr_hex).unwrap();
+                let target = utils::hex_to_address(&target_addr_hex)?;
                 let amount = amount
                     .as_ref()
                     .map_or_else(Wei::zero, |a| Wei::new(U256::from_dec_str(a).unwrap()));
-                let input = hex::decode(input_data_hex)?;
+                let input = utils::hex_to_vec(&input_data_hex)?;
                 send_transaction(client, &sk, Some(target), amount, input).await?;
             }
         },

--- a/src/cli/erc20.rs
+++ b/src/cli/erc20.rs
@@ -1,4 +1,5 @@
-use aurora_engine_types::{types::Address, U256};
+use crate::utils;
+use aurora_engine_types::U256;
 use clap::Subcommand;
 
 const APPROVE_SELECTOR: &[u8] = &[0x09, 0x5e, 0xa7, 0xb3];
@@ -50,7 +51,7 @@ impl Erc20 {
                 to_address_hex,
                 amount,
             } => {
-                let to = Address::decode(&to_address_hex).map_err(wrap_error)?;
+                let to = utils::hex_to_address(&to_address_hex).map_err(wrap_error)?;
                 let amount = U256::from_str_radix(&amount, 10).map_err(wrap_error)?;
                 let input = [
                     TRANSFER_SELECTOR,
@@ -66,8 +67,8 @@ impl Erc20 {
                 owner_address_hex,
                 spender_address_hex,
             } => {
-                let spender = Address::decode(&spender_address_hex).map_err(wrap_error)?;
-                let owner = Address::decode(&owner_address_hex).map_err(wrap_error)?;
+                let spender = utils::hex_to_address(&spender_address_hex).map_err(wrap_error)?;
+                let owner = utils::hex_to_address(&owner_address_hex).map_err(wrap_error)?;
                 let input = [
                     ALLOWANCE_SELECTOR,
                     &ethabi::encode(&[
@@ -82,7 +83,7 @@ impl Erc20 {
                 spender_address_hex,
                 amount,
             } => {
-                let spender = Address::decode(&spender_address_hex).map_err(wrap_error)?;
+                let spender = utils::hex_to_address(&spender_address_hex).map_err(wrap_error)?;
                 let amount = U256::from_str_radix(&amount, 10).map_err(wrap_error)?;
                 let input = [
                     APPROVE_SELECTOR,
@@ -95,7 +96,7 @@ impl Erc20 {
                 Ok(input)
             }
             Self::BalanceOf { address_hex } => {
-                let address = Address::decode(&address_hex).map_err(wrap_error)?;
+                let address = utils::hex_to_address(&address_hex).map_err(wrap_error)?;
                 let input = [
                     BALANCE_OF_SELECTOR,
                     &ethabi::encode(&[ethabi::Token::Address(address.raw())]),
@@ -108,8 +109,8 @@ impl Erc20 {
                 amount,
                 from_address_hex,
             } => {
-                let from = Address::decode(&from_address_hex).map_err(wrap_error)?;
-                let to = Address::decode(&to_address_hex).map_err(wrap_error)?;
+                let from = utils::hex_to_address(&from_address_hex).map_err(wrap_error)?;
+                let to = utils::hex_to_address(&to_address_hex).map_err(wrap_error)?;
                 let amount = U256::from_str_radix(&amount, 10).map_err(wrap_error)?;
                 let input = [
                     TRANSFER_FROM_SELECTOR,

--- a/src/cli/process_tx_data.rs
+++ b/src/cli/process_tx_data.rs
@@ -1,5 +1,7 @@
-use crate::transaction_reader::{self, aggregator, filter};
-use aurora_engine_types::types::Address;
+use crate::{
+    transaction_reader::{self, aggregator, filter},
+    utils,
+};
 use clap::Subcommand;
 use std::sync::Arc;
 
@@ -60,7 +62,7 @@ pub async fn execute_command(action: ProcessTxAction, input_files_list_path: Str
             }
         }
         ProcessTxAction::FilterTo { target_addr_hex } => {
-            let to = Address::decode(&target_addr_hex).unwrap();
+            let to = utils::hex_to_address(&target_addr_hex).unwrap();
             let f = Arc::new(filter::EthTxTo(to));
             transaction_reader::process_data::<aggregator::Echo, _>(paths, &f).await;
         }

--- a/src/cli/solidity.rs
+++ b/src/cli/solidity.rs
@@ -1,5 +1,8 @@
-use crate::cli::erc20::{wrap_error, ParseError};
-use aurora_engine_types::{types::Address, U256};
+use crate::{
+    cli::erc20::{wrap_error, ParseError},
+    utils,
+};
+use aurora_engine_types::U256;
 use clap::Subcommand;
 use serde_json::Value;
 
@@ -102,11 +105,11 @@ fn read_arg(arg: Option<String>, stdin_arg: Option<bool>) -> String {
 fn parse_arg(arg: &str, kind: &ethabi::ParamType) -> Result<ethabi::Token, ParseError> {
     match kind {
         ethabi::ParamType::Address => {
-            let addr = Address::decode(arg).map_err(wrap_error)?;
+            let addr = utils::hex_to_address(arg).map_err(wrap_error)?;
             Ok(ethabi::Token::Address(addr.raw()))
         }
         ethabi::ParamType::Bytes => {
-            let bytes = hex::decode(arg).map_err(wrap_error)?;
+            let bytes = utils::hex_to_vec(arg).map_err(wrap_error)?;
             Ok(ethabi::Token::Bytes(bytes))
         }
         ethabi::ParamType::Int(_) => {
@@ -128,7 +131,7 @@ fn parse_arg(arg: &str, kind: &ethabi::ParamType) -> Result<ethabi::Token, Parse
             parse_array(value, arr_kind).map(ethabi::Token::Array)
         }
         ethabi::ParamType::FixedBytes(size) => {
-            let bytes = hex::decode(arg).map_err(wrap_error)?;
+            let bytes = utils::hex_to_vec(arg).map_err(wrap_error)?;
             if &bytes.len() != size {
                 return Err(wrap_error("Incorrect FixedBytes length"));
             }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,10 +5,18 @@ use near_crypto::InMemorySigner;
 use rlp::RlpStream;
 use std::{io, path::Path};
 
-pub fn hex_to_arr32(h: &str) -> Result<[u8; 32], hex::FromHexError> {
-    let mut output = [0u8; 32];
-    hex::decode_to_slice(h, &mut output)?;
+pub fn hex_to_arr<const N: usize>(h: &str) -> Result<[u8; N], hex::FromHexError> {
+    let mut output = [0u8; N];
+    hex::decode_to_slice(h.strip_prefix("0x").unwrap_or(h), &mut output)?;
     Ok(output)
+}
+
+pub fn hex_to_address(h: &str) -> Result<Address, hex::FromHexError> {
+    hex_to_arr(h).map(Address::from_array)
+}
+
+pub fn hex_to_vec(h: &str) -> Result<Vec<u8>, hex::FromHexError> {
+    hex::decode(h.strip_prefix("0x").unwrap_or(h))
 }
 
 pub fn address_from_secret_key(sk: &SecretKey) -> Address {


### PR DESCRIPTION
The `hex` crate and `Address::decode` functions do not expect an `0x` prefix on hex-encoded data. However it is standard to include such a prefix for most blockchain RPCs / explorers. For ease of use, it make sense for the CLI to accept an `0x` prefix too.

This PR adds some new functions to the `utils` module that can parse hex-encoded data with an `0x` prefix and then uses those new functions throughout the code.