### PR TITLE
chore: add shell tests for testing advanced cli

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,3 +74,21 @@ jobs:
         with:
           command: test
           args: --all-targets
+
+  shell_tests:
+    name: Shell Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - name: Install aurora-cli
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --path .
+      - name: Tests
+        run: scripts/advanced.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ repository = "https://github.com/aurora-is-near/aurora-cli-rs"
 description = "Aurora CLI is a command line interface to bootstrap Aurora engine"
 readme = "README.md"
 
+[[bin]]
+name = "aurora-cli"
+path = "src/main.rs"
+
 [dependencies]
 aurora-engine = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.1", features = ["std"] }
 aurora-engine-precompiles = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.1", features = ["std"] }

--- a/scripts/advanced.sh
+++ b/scripts/advanced.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -e
+
+EVM_CODE=$(cat docs/res/HelloWorld.hex)
+ABI_PATH="docs/res/HelloWorld.abi"
+ENGINE_WASM_URL="https://github.com/aurora-is-near/aurora-engine/releases/download/latest/aurora-mainnet.wasm"
+ENGINE_WASM_PATH="/tmp/aurora-mainnet.wasm"
+USER_BASE_BIN=$(python3 -m site --user-base)/bin
+
+export PATH="$PATH:$USER_BASE_BIN"
+export NEARCORE_HOME="/tmp/localnet"
+
+# Install `nearup` utility if not installed before.
+if $(pip3 list | grep nearup > /dev/null); then
+  echo "nearup has been already installed"
+else
+  pip3 install --user nearup
+fi
+
+start_node() {
+  nearup run localnet --num-nodes 1 --home $NEARCORE_HOME --no-watcher > /dev/null 2>&1
+}
+
+finish() {
+  # Stop NEAR node.
+  nearup stop > /dev/null 2>&1
+  # Cleanup
+  rm -rf $NEARCORE_HOME
+  exit
+}
+
+# Download `neard` and preparing config files.
+start_node
+nearup stop > /dev/null 2>&1
+sleep 2
+
+# Update configs and add aurora key.
+aurora-cli near init genesis --path $NEARCORE_HOME/node0/genesis.json
+aurora-cli near init local-config -n $NEARCORE_HOME/node0/config.json -a $NEARCORE_HOME/node0/aurora_key.json
+
+# Start NEAR node.
+rm -rf $NEARCORE_HOME/node0/data
+start_node
+sleep 1
+
+# Download Aurora EVM.
+curl -sL $ENGINE_WASM_URL -o $ENGINE_WASM_PATH || finish
+
+# Deploy and init Aurora EVM smart contract.
+aurora-cli near write engine-init -w $ENGINE_WASM_PATH || finish
+sleep 2
+
+# Deploy EVM code.
+aurora-cli near write deploy-code $EVM_CODE || finish
+sleep 2
+
+# Run EVM view call.
+aurora-cli near read solidity -t 0x592186c059e3d9564cac6b1ada6f2dc7ff1d78e9 call-args-by-name \
+    --abi-path $ABI_PATH -m "greet" --arg '{}'
+
+finish

--- a/scripts/advanced.sh
+++ b/scripts/advanced.sh
@@ -8,7 +8,7 @@ ENGINE_WASM_URL="https://github.com/aurora-is-near/aurora-engine/releases/downlo
 ENGINE_WASM_PATH="/tmp/aurora-mainnet.wasm"
 USER_BASE_BIN=$(python3 -m site --user-base)/bin
 
-export PATH="$PATH:$USER_BASE_BIN"
+export PATH="$PATH:$USER_BASE_BIN:$HOME/.cargo/bin"
 export NEARCORE_HOME="/tmp/localnet"
 
 # Install `nearup` utility if not installed before.


### PR DESCRIPTION
The PR adds some integration tests for checking advanced CLI for such operations:

- deployment Aurora EVM smart contract
- deployment EVM code
- call view method of the EVM smart contract