### PR TITLE
feat: add support methods related to eth-connector

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Install python-venv
-        run: apt install python3-venv
+        run: apt -y install python3-venv
       - name: Install aurora-cli
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   shell_tests:
     name: Tests ${{ matrix.interface }} CLI
-    runs-on: [self-hosted, heavy]
+    runs-on: [ self-hosted, heavy ]
     strategy:
       matrix:
         interface: [ Advanced, Simple, Silo ]
@@ -27,10 +27,11 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-      - name: Install aurora-cli (Advanced CLI)
+      - name: Install python-venv
+        run: apt install python3-venv
+      - name: Install aurora-cli
         uses: actions-rs/cargo@v1
         with:
           command: install
           args: ${{ matrix.args }}
       - run: ${{ matrix.script }}
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,14 +4,14 @@ version = 3
 
 [[package]]
 name = "actix"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb72882332b6d6282f428b77ba0358cb2687e61a6f6df6a6d3871e8a177c2d4f"
+checksum = "de7fa236829ba0841304542f7614c42b80fca007455315c45c785ccfa873a85b"
 dependencies = [
  "actix-macros",
  "actix-rt",
  "actix_derive",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "bytes",
  "crossbeam-channel",
  "futures-core",
@@ -24,7 +24,7 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util",
 ]
 
 [[package]]
@@ -34,14 +34,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.53",
+ "syn 2.0.69",
 ]
 
 [[package]]
 name = "actix-rt"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28f32d40287d3f402ae0028a9d54bef51af15c8769492826a69d28f81893151d"
+checksum = "24eda4e2a6e042aa4e55ac438a2ae052d3b5da0ecf83d7411e1a368946925208"
 dependencies = [
  "futures-core",
  "tokio",
@@ -55,14 +55,14 @@ checksum = "7c7db3d5a9718568e4cf4a537cfd7070e6e6ff7481510d0237fb529ac850f6d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.69",
 ]
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
  "gimli",
 ]
@@ -79,28 +79,16 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom",
  "once_cell",
  "version_check",
-]
-
-[[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -122,47 +110,48 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -170,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "arbitrary"
@@ -196,12 +185,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
-name = "assert_matches"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
-
-[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,19 +203,25 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.69",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.78"
+version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.69",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aurora-cli-rs"
@@ -243,7 +232,8 @@ dependencies = [
  "aurora-engine-sdk",
  "aurora-engine-transactions",
  "aurora-engine-types",
- "bs58 0.5.0",
+ "borsh 1.5.1",
+ "bs58 0.5.1",
  "clap",
  "ethabi",
  "hex",
@@ -254,7 +244,7 @@ dependencies = [
  "near-jsonrpc-client",
  "near-jsonrpc-primitives",
  "near-primitives",
- "rand 0.8.5",
+ "rand",
  "reqwest",
  "rlp",
  "serde",
@@ -262,13 +252,13 @@ dependencies = [
  "shadow-rs",
  "thiserror",
  "tokio",
- "toml 0.8.12",
+ "toml 0.8.14",
 ]
 
 [[package]]
 name = "aurora-engine-modexp"
 version = "1.0.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.6.1#26a126231e1ce338598a7d9909779f32e4dce8a2"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.6.3#932412d1863dd8d4f9e4c1521d94364f08ce0eb7"
 dependencies = [
  "hex",
  "num",
@@ -277,7 +267,7 @@ dependencies = [
 [[package]]
 name = "aurora-engine-precompiles"
 version = "1.0.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.6.1#26a126231e1ce338598a7d9909779f32e4dce8a2"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.6.3#932412d1863dd8d4f9e4c1521d94364f08ce0eb7"
 dependencies = [
  "aurora-engine-modexp",
  "aurora-engine-sdk",
@@ -296,7 +286,7 @@ dependencies = [
 [[package]]
 name = "aurora-engine-sdk"
 version = "1.0.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.6.1#26a126231e1ce338598a7d9909779f32e4dce8a2"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.6.3#932412d1863dd8d4f9e4c1521d94364f08ce0eb7"
 dependencies = [
  "aurora-engine-types",
  "base64 0.21.7",
@@ -307,7 +297,7 @@ dependencies = [
 [[package]]
 name = "aurora-engine-transactions"
 version = "1.0.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.6.1#26a126231e1ce338598a7d9909779f32e4dce8a2"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.6.3#932412d1863dd8d4f9e4c1521d94364f08ce0eb7"
 dependencies = [
  "aurora-engine-precompiles",
  "aurora-engine-sdk",
@@ -319,11 +309,11 @@ dependencies = [
 [[package]]
 name = "aurora-engine-types"
 version = "1.0.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.6.1#26a126231e1ce338598a7d9909779f32e4dce8a2"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.6.3#932412d1863dd8d4f9e4c1521d94364f08ce0eb7"
 dependencies = [
  "base64 0.21.7",
- "borsh 0.10.3",
- "bs58 0.5.0",
+ "borsh 1.5.1",
+ "bs58 0.5.1",
  "hex",
  "primitive-types 0.12.2",
  "rlp",
@@ -339,20 +329,65 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.69",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.29",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 0.1.2",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
@@ -376,6 +411,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,9 +424,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bitvec"
@@ -401,13 +442,11 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.9.2"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e37d16930f5459780f5621038b6382b9bb37c19016f39fb6b5808d831f174"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "crypto-mac",
- "digest 0.9.0",
- "opaque-debug",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -440,21 +479,11 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "0.10.3"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
+checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
 dependencies = [
- "borsh-derive 0.10.3",
- "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "borsh"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b559fd6448c6e2fd0adb5720cd98a2506594cafa4737ff98c396f3e82f667"
-dependencies = [
- "borsh-derive 1.3.1",
+ "borsh-derive 1.5.1",
  "cfg_aliases",
 ]
 
@@ -464,8 +493,8 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6441c552f230375d18e3cc377677914d2ca2b0d36e52129fe15450a2dce46775"
 dependencies = [
- "borsh-derive-internal 0.9.3",
- "borsh-schema-derive-internal 0.9.3",
+ "borsh-derive-internal",
+ "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
  "proc-macro2",
  "syn 1.0.109",
@@ -473,28 +502,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "0.10.3"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0754613691538d51f329cce9af41d7b7ca150bc973056f1156611489475f54f7"
-dependencies = [
- "borsh-derive-internal 0.10.3",
- "borsh-schema-derive-internal 0.10.3",
- "proc-macro-crate 0.1.5",
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aadb5b6ccbd078890f6d7003694e33816e6b784358f18e15e7e6d9f065a57cd"
+checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
 dependencies = [
  "once_cell",
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.69",
  "syn_derive",
 ]
 
@@ -503,17 +519,6 @@ name = "borsh-derive-internal"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive-internal"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -532,17 +537,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "borsh-schema-derive-internal"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,9 +544,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bs58"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "sha2 0.10.8",
  "tinyvec",
@@ -560,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.4"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byte-slice-cast"
@@ -578,9 +572,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "bytesize"
@@ -592,23 +586,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "c2-chacha"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d27dae93fe7b1e0424dc57179ac396908c26b035a87234809f5c4dfd1b47dc80"
-dependencies = [
- "cipher",
- "ppv-lite86",
-]
-
-[[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "5208975e568d83b6b05cc0a063c8e7e9acc2b43bee6da15616a5b73e109d7437"
 dependencies = [
  "jobserver",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -619,15 +604,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.35"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -635,23 +620,14 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.4",
-]
-
-[[package]]
-name = "cipher"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
-dependencies = [
- "generic-array",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.3"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
+checksum = "84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -659,45 +635,45 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.0",
+ "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.3"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
+checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.69",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "const_fn"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
+checksum = "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d"
 
 [[package]]
 name = "const_format"
@@ -752,18 +728,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crunchy"
@@ -793,17 +769,16 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "platforms",
- "rand_core 0.6.4",
+ "rand_core",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -817,14 +792,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.69",
 ]
 
 [[package]]
 name = "darling"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -832,27 +807,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
- "syn 2.0.53",
+ "strsim",
+ "syn 2.0.69",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.69",
 ]
 
 [[package]]
@@ -873,20 +848,20 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.69",
 ]
 
 [[package]]
 name = "derive_more"
-version = "0.99.17"
+version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 1.0.109",
+ "syn 2.0.69",
 ]
 
 [[package]]
@@ -906,6 +881,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -931,22 +907,22 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core 0.6.4",
+ "rand_core",
  "sha2 0.10.8",
  "subtle",
 ]
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.33"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
 ]
@@ -968,7 +944,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.69",
 ]
 
 [[package]]
@@ -985,9 +961,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1115,15 +1091,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.6"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1676f435fc1dadde4d03e43f5d62b259e1ce5f40bd4ffb21db2b42ebe59c1382"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fixed-hash"
@@ -1141,16 +1117,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand",
  "rustc-hex",
  "static_assertions",
 ]
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fnv"
@@ -1183,16 +1153,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,6 +1166,7 @@ checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1246,6 +1207,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.69",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,6 +1238,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1286,39 +1259,28 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "git2"
-version = "0.18.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b3ba52851e73b46a4c3df1d89343741112003f0f6f13beb0dfac9e457c3fdcd"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -1326,21 +1288,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.3.25"
+name = "glob"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "h2"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
- "indexmap 2.2.5",
+ "http 0.2.12",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -1365,7 +1352,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash 0.7.8",
+ "ahash",
 ]
 
 [[package]]
@@ -1376,27 +1363,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash 0.8.11",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heck"
@@ -1447,19 +1416,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
@@ -1473,15 +1444,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -1491,17 +1485,17 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "0.14.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1514,12 +1508,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4fe55fb7a772d59a5ff1dfbff4fe0258d19b89fec4b233e75d35d5d2316badc"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.4.0",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.29",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -1527,15 +1558,38 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
- "hyper",
+ "http-body-util",
+ "hyper 1.4.0",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.4.0",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1628,12 +1682,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "serde",
 ]
 
@@ -1650,6 +1704,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06d198e9919d9822d5f7083ba8530e04de87841eaf21ead9af8f2304efd57c89"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,16 +1719,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.10"
+name = "itertools"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
 ]
@@ -1699,24 +1768,24 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.16.2+1.7.2"
+version = "0.17.0+1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
 dependencies = [
  "cc",
  "libc",
@@ -1737,7 +1806,7 @@ dependencies = [
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand 0.8.5",
+ "rand",
  "serde",
  "sha2 0.9.9",
  "typenum",
@@ -1774,9 +1843,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.15"
+version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
+checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
 dependencies = [
  "cc",
  "libc",
@@ -1786,15 +1855,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1802,9 +1871,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "matchers"
@@ -1816,19 +1885,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "2.7.1"
+name = "matchit"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
-name = "memoffset"
-version = "0.8.0"
+name = "memchr"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
-dependencies = [
- "autocfg",
-]
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mime"
@@ -1838,9 +1904,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -1852,23 +1918,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
-name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
 name = "native-tls"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
 dependencies = [
- "lazy_static",
  "libc",
  "log",
  "openssl",
@@ -1886,20 +1945,52 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35cbb989542587b47205e608324ddd391f0cee1c22b4b64ae49f458334b95907"
 dependencies = [
- "borsh 1.3.1",
+ "borsh 1.5.1",
  "serde",
 ]
 
 [[package]]
-name = "near-chain-configs"
-version = "0.20.1"
+name = "near-async"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e5a8ace81c09d7eb165dffc1742358a021b2fa761f2160943305f83216003"
+checksum = "754fd9af13f1241520e8fc4831ff5c582ee00a6b1221c0cbd8bf43d059ed6e04"
+dependencies = [
+ "actix",
+ "derive_more",
+ "futures",
+ "near-async-derive",
+ "near-o11y",
+ "near-performance-metrics",
+ "near-time",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
+]
+
+[[package]]
+name = "near-async-derive"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a47ae519ceed7636e3d9328fd7d1bcbda9a28eccee73315e0a3139e99aa1232"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.69",
+]
+
+[[package]]
+name = "near-chain-configs"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75447355021100158c2e5fc151a0f6728e794b98cb411874f89fc5fb9f386cd2"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
  "derive_more",
+ "near-async",
  "near-config-utils",
  "near-crypto",
  "near-parameters",
@@ -1910,14 +2001,15 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "smart-default",
+ "time",
  "tracing",
 ]
 
 [[package]]
 name = "near-config-utils"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae1eaab1d545a9be7a55b6ef09f365c2017f93a03063547591d12c0c6d27e58"
+checksum = "43b3db4ac2d4340caef06b6363c3fd16c0be1f70267908dfa53e2e6241649b0c"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -1927,14 +2019,13 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2991d2912218a80ec0733ac87f84fa803accea105611eea209d4419271957667"
+checksum = "b9807fb257f7dda41383bb33e14cfd4a8840ffa7932cb972db9eabff19ce3bf4"
 dependencies = [
  "blake2",
- "borsh 1.3.1",
+ "borsh 1.5.1",
  "bs58 0.4.0",
- "c2-chacha",
  "curve25519-dalek",
  "derive_more",
  "ed25519-dalek",
@@ -1944,7 +2035,6 @@ dependencies = [
  "near-stdx",
  "once_cell",
  "primitive-types 0.10.1",
- "rand 0.7.3",
  "secp256k1",
  "serde",
  "serde_json",
@@ -1954,20 +2044,20 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d998dfc1e04001608899b2498ad5a782c7d036b73769d510de21964db99286"
+checksum = "00ce363e4078b870775e2a5a5189feae22f0870ca673f6409b1974922dada0c4"
 dependencies = [
  "near-primitives-core",
 ]
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "0.8.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18ad81e015f7aced8925d5b9ba3f369b36da9575c15812cfd0786bc1213284ca"
+checksum = "9b40b427519fcbf71be4de4cab4f6c201aa3e3fb212a4a54976596fa44b05711"
 dependencies = [
- "borsh 1.3.1",
+ "borsh 1.5.1",
  "lazy_static",
  "log",
  "near-chain-configs",
@@ -1982,9 +2072,9 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0ce745e954ae776eef05957602e638ee9581106a3675946fb43c2fe7e38ef03"
+checksum = "7e30db3829a8880847d7f3f64828f11133ba9102d2df382a2d916ec1553270df"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -1994,28 +2084,28 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "time",
 ]
 
 [[package]]
 name = "near-o11y"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20762631bc8253030013bbae9b5f0542691edc1aa6722f1e8141cc9b928ae5b"
+checksum = "2847f81f7a4c996d583c377f8196a8d05d74ee7535678c20beef0f80304c48b1"
 dependencies = [
  "actix",
  "base64 0.21.7",
  "clap",
  "near-crypto",
- "near-fmt",
  "near-primitives-core",
  "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
  "prometheus",
  "serde",
  "serde_json",
- "strum",
  "thiserror",
  "tokio",
  "tracing",
@@ -2026,12 +2116,11 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f16a59b6c3e69b0585be951af6fe42a0ba86c0e207cb8c63badd19efd16680"
+checksum = "fddf39f5f729976a791d86e0e30a71ec4d8e8dcf58117c8694e7b22fb3f50ee6"
 dependencies = [
- "assert_matches",
- "borsh 1.3.1",
+ "borsh 1.5.1",
  "enum-map",
  "near-account-id",
  "near-primitives-core",
@@ -2044,14 +2133,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-primitives"
-version = "0.20.1"
+name = "near-performance-metrics"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0462b067732132babcc89d5577db3bfcb0a1bcfbaaed3f2db4c11cd033666314"
+checksum = "42166c93c35457d16a3a6c7b9b511bea790bcb4a35a41d4c5218b1fb9a46702a"
+dependencies = [
+ "actix",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures",
+ "libc",
+ "once_cell",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "near-primitives"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d58c175262923db9885ed0347e96ec3bcbec57825e3b6d7de03da220f5e14ef5"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
- "borsh 1.3.1",
+ "borsh 1.5.1",
+ "bytes",
  "bytesize",
  "cfg-if",
  "chrono",
@@ -2059,41 +2166,40 @@ dependencies = [
  "easy-ext",
  "enum-map",
  "hex",
+ "itertools 0.10.5",
  "near-crypto",
  "near-fmt",
- "near-o11y",
  "near-parameters",
  "near-primitives-core",
  "near-rpc-error-macro",
  "near-stdx",
- "near-vm-runner",
+ "near-time",
  "num-rational 0.3.2",
  "once_cell",
  "primitive-types 0.10.1",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand",
+ "rand_chacha",
  "reed-solomon-erasure",
  "serde",
  "serde_json",
  "serde_with",
- "serde_yaml",
  "sha3",
  "smart-default",
  "strum",
  "thiserror",
- "time",
  "tracing",
+ "zstd",
 ]
 
 [[package]]
 name = "near-primitives-core"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8443eb718606f572c438be6321a097a8ebd69f8e48d953885b4f16601af88225"
+checksum = "45de00d413f5bb890a3912f32fcd0974b2b0a975cc7874012e2c4c4fa7f28917"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
- "borsh 1.3.1",
+ "borsh 1.5.1",
  "bs58 0.4.0",
  "derive_more",
  "enum-map",
@@ -2101,69 +2207,48 @@ dependencies = [
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
- "serde_with",
  "sha2 0.10.8",
- "strum",
  "thiserror",
 ]
 
 [[package]]
 name = "near-rpc-error-core"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80fca203c51edd9595ec14db1d13359fb9ede32314990bf296b6c5c4502f6ab7"
+checksum = "cf41b149dcc1f5a35d6a96fbcd8c28c92625c05b52025a72ee7378c72bcd68ce"
 dependencies = [
  "quote",
  "serde",
- "syn 2.0.53",
+ "syn 2.0.69",
 ]
 
 [[package]]
 name = "near-rpc-error-macro"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897a445de2102f6732c8a185d922f5e3bf7fd0a41243ce40854df2197237f799"
+checksum = "73c7f0f12f426792dd2c9d83df43d73c3b15d80f6e99e8d0e16ff3e024d0f9ba"
 dependencies = [
- "fs2",
  "near-rpc-error-core",
  "serde",
- "syn 2.0.53",
+ "syn 2.0.69",
 ]
 
 [[package]]
 name = "near-stdx"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "855fd5540e3b4ff6fedf12aba2db1ee4b371b36f465da1363a6d022b27cb43b8"
+checksum = "29e1897481272eb144328abd51ca9f59b5b558e7a6dc6e2177c8c9bb18fbd818"
 
 [[package]]
-name = "near-vm-runner"
-version = "0.20.1"
+name = "near-time"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56c80bdb1954808f59bd36a9112377197b38d424991383bf05f52d0fe2e0da5"
+checksum = "a56db32f26b089441c1a7c5451f0d68637afa9d66f6d8f6a6f2d6c2f7953520a"
 dependencies = [
- "base64 0.21.7",
- "borsh 1.3.1",
- "ed25519-dalek",
- "enum-map",
- "memoffset",
- "near-crypto",
- "near-parameters",
- "near-primitives-core",
- "near-stdx",
- "num-rational 0.3.2",
  "once_cell",
- "prefix-sum-vec",
- "ripemd",
  "serde",
- "serde_repr",
- "serde_with",
- "sha2 0.10.8",
- "sha3",
- "strum",
- "thiserror",
- "tracing",
- "zeropool-bn",
+ "time",
+ "tokio",
 ]
 
 [[package]]
@@ -2178,15 +2263,15 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint 0.4.4",
+ "num-bigint 0.4.6",
  "num-complex",
  "num-integer",
  "num-iter",
- "num-rational 0.4.1",
+ "num-rational 0.4.2",
  "num-traits",
 ]
 
@@ -2203,20 +2288,19 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
 
 [[package]]
 name = "num-complex"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
@@ -2238,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -2262,21 +2346,20 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "autocfg",
- "num-bigint 0.4.4",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -2302,9 +2385,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
 dependencies = [
  "memchr",
 ]
@@ -2327,7 +2410,7 @@ version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2344,7 +2427,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.69",
 ]
 
 [[package]]
@@ -2355,9 +2438,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.101"
+version = "0.9.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
 dependencies = [
  "cc",
  "libc",
@@ -2367,50 +2450,85 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.17.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
+checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http 0.2.12",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
  "futures-channel",
  "futures-executor",
  "futures-util",
- "js-sys",
- "lazy_static",
+ "glob",
+ "once_cell",
+ "opentelemetry",
+ "ordered-float",
  "percent-encoding",
- "pin-project",
- "rand 0.8.5",
+ "rand",
  "thiserror",
  "tokio",
  "tokio-stream",
 ]
 
 [[package]]
-name = "opentelemetry-otlp"
-version = "0.10.0"
+name = "ordered-float"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1a6ca9de4c8b00aa7f1a153bd76cb263287155cec642680d79d98706f3d28a"
+checksum = "19ff2cf528c6c03d9ed653d6c4ce1dc0582dc4af309790ad92f07c1cd551b0be"
 dependencies = [
- "async-trait",
- "futures",
- "futures-util",
- "http",
- "opentelemetry",
- "prost",
- "thiserror",
- "tokio",
- "tonic",
- "tonic-build",
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985cc35d832d412224b2cffe2f9194b1b89b6aa5d0bef76d080dce09d90e62bd"
-dependencies = [
- "opentelemetry",
+ "num-traits",
 ]
 
 [[package]]
@@ -2421,9 +2539,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.9"
+version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881331e34fa842a2fb61cc2db9643a8fedc615e47cfcc52597d1af0db9a7e8fe"
+checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -2435,11 +2553,11 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.9"
+version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be30eaf4b0a9fba5336683b38de57bb86d179a35862ba6bfcf57625d006bde5b"
+checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -2447,9 +2565,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2457,15 +2575,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2473,16 +2591,6 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "petgraph"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
-dependencies = [
- "fixedbitset",
- "indexmap 2.2.5",
-]
 
 [[package]]
 name = "pin-project"
@@ -2501,14 +2609,14 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.69",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -2523,12 +2631,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
-name = "platforms"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
-
-[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2539,12 +2641,6 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "prefix-sum-vec"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa06bd51638b6e76ac9ba9b6afb4164fa647bd2916d722f2623fbb6d1ed8bdba"
 
 [[package]]
 name = "primitive-types"
@@ -2581,25 +2677,6 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
-dependencies = [
- "toml_edit 0.20.7",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
@@ -2632,18 +2709,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prometheus"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
 dependencies = [
  "cfg-if",
  "fnv",
@@ -2656,55 +2733,25 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.9.0"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
  "prost-derive",
 ]
 
 [[package]]
-name = "prost-build"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
-dependencies = [
- "bytes",
- "heck 0.3.3",
- "itertools",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prost",
- "prost-types",
- "regex",
- "tempfile",
- "which",
-]
-
-[[package]]
 name = "prost-derive"
-version = "0.9.0"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
-dependencies = [
- "bytes",
- "prost",
+ "syn 2.0.69",
 ]
 
 [[package]]
@@ -2715,9 +2762,9 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -2730,36 +2777,13 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -2769,16 +2793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -2787,25 +2802,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.12",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -2819,14 +2825,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.2",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -2840,13 +2846,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -2857,26 +2863,29 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
-version = "0.11.26"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bf93c4af7a8bb7d879d51cebe797356ff10ae8516ace542b5182d9dcac10b2"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.4.0",
+ "hyper-rustls",
  "hyper-tls",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -2889,7 +2898,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.1",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -2899,6 +2908,21 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2934,9 +2958,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hex"
@@ -2955,11 +2979,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.31"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2967,31 +2991,62 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
+name = "rustls"
+version = "0.23.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
 dependencies = [
- "base64 0.21.7",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "scale-info"
-version = "2.11.0"
+version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef2175c2907e7c8bc0a9c3f86aeb5ec1f3b275300ad58a44d0c3ae379a5e52e"
+checksum = "eca070c12893629e2cc820a9761bedf6ce1dcddc9852984d1dc734b8bd9bd024"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3002,11 +3057,11 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.11.0"
+version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b8eb8fd61c5cdd3390d9b2132300a7e7618955b98b8416f118c1b4e144f"
+checksum = "2d35494501194174bda522a32605929eefc9ecf7e0a326c26db1fdd85881eb62"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3033,7 +3088,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
- "rand 0.8.5",
+ "rand",
  "secp256k1-sys",
 ]
 
@@ -3048,11 +3103,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.2"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3061,9 +3116,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3071,35 +3126,35 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.69",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
@@ -3108,20 +3163,20 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.69",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
 dependencies = [
  "serde",
 ]
@@ -3140,15 +3195,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.7.0"
+version = "3.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee80b0e361bbf88fd2f6e242ccd19cfda072cb0faa6ae694ecee08199938569a"
+checksum = "e73139bc5ec2d45e6c5fd85be5a46949c1c39a4c18e56915f5eb4c12f975e377"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3158,23 +3213,23 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.7.0"
+version = "3.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6561dc161a9224638a31d876ccdfefbc1df91d3f3a8342eddb35f055d48c7655"
+checksum = "b80d3d6b56b64335c0180e5ffde23b3c5e08c14c585b51a15bd0e95393f46703"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.69",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.33"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0623d197252096520c6f2a5e1171ee436e5af99a5d7caa2891e55e61950e6d9"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -3217,9 +3272,9 @@ dependencies = [
 
 [[package]]
 name = "shadow-rs"
-version = "0.27.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7960cbd6ba74691bb15e7ebf97f7136bd02d1115f5695a58c1f31d5645750128"
+checksum = "0a600f795d0894cda22235b44eea4b85c2a35b405f65523645ac8e35b306817a"
 dependencies = [
  "const_format",
  "git2",
@@ -3239,9 +3294,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
@@ -3263,9 +3318,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smart-default"
@@ -3280,9 +3335,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -3290,9 +3345,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "static_assertions"
@@ -3302,15 +3357,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -3336,9 +3385,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -3353,9 +3402,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.53"
+version = "2.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
+checksum = "201fcda3845c23e8212cd466bfebf0bd20694490fc0356ae8e428e0824a915a6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3371,7 +3420,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.69",
 ]
 
 [[package]]
@@ -3379,6 +3428,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "system-configuration"
@@ -3421,22 +3476,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.69",
 ]
 
 [[package]]
@@ -3451,9 +3506,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -3474,9 +3529,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3493,9 +3548,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "ce6b6a2fb3a985e99cebfaefa9faa3024743da73304ca1c683a36429613d3d22"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3508,9 +3563,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3537,13 +3592,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.69",
 ]
 
 [[package]]
@@ -3553,6 +3608,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -3569,30 +3635,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -3606,45 +3657,23 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.8",
+ "toml_edit 0.22.14",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap 2.2.5",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.20.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
-dependencies = [
- "indexmap 2.2.5",
- "toml_datetime",
- "winnow 0.5.40",
 ]
 
 [[package]]
@@ -3653,65 +3682,49 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "toml_datetime",
  "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.8"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c12219811e0c1ba077867254e5ad62ee2c9c190b0d957110750ac0cda1ae96cd"
+checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.5",
+ "winnow 0.6.13",
 ]
 
 [[package]]
 name = "tonic"
-version = "0.6.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
  "async-stream",
  "async-trait",
- "base64 0.13.1",
+ "axum",
+ "base64 0.21.7",
  "bytes",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.29",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
  "prost",
- "prost-derive",
  "tokio",
  "tokio-stream",
- "tokio-util 0.6.10",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "tonic-build"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
-dependencies = [
- "proc-macro2",
- "prost-build",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -3725,10 +3738,10 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "slab",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3752,7 +3765,6 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3778,7 +3790,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.69",
 ]
 
 [[package]]
@@ -3789,27 +3801,6 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
 ]
 
 [[package]]
@@ -3825,16 +3816,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.17.4"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbe89715c1dbbb790059e2565353978564924ee85017b5fff365c872ff6721f"
+checksum = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284"
 dependencies = [
+ "js-sys",
  "once_cell",
  "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
  "tracing",
  "tracing-core",
- "tracing-log 0.1.4",
+ "tracing-log",
  "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -3852,7 +3847,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3940,12 +3935,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3958,10 +3947,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
-name = "url"
-version = "2.5.0"
+name = "untrusted"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3969,10 +3964,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf8parse"
-version = "0.2.1"
+name = "urlencoding"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"
@@ -4003,12 +4004,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -4034,7 +4029,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.69",
  "wasm-bindgen-shared",
 ]
 
@@ -4068,7 +4063,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.69",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4090,15 +4085,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.4.2"
+name = "web-time"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4129,7 +4122,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4147,7 +4140,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4167,17 +4160,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -4188,9 +4182,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4200,9 +4194,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4212,9 +4206,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4224,9 +4224,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4236,9 +4236,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4248,9 +4248,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4260,9 +4260,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -4275,18 +4275,18 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.5"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "winreg"
-version = "0.50.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
@@ -4302,30 +4302,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.7.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.53",
-]
-
-[[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zeropool-bn"
@@ -4337,6 +4317,34 @@ dependencies = [
  "byteorder",
  "crunchy",
  "lazy_static",
- "rand 0.8.5",
+ "rand",
  "rustc-hex",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa556e971e7b568dc775c136fc9de8c779b1c2fc3a63defaafadffdbd3181afa"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.12+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,32 +19,33 @@ simple = ["toml"]
 advanced = ["near-chain-configs"]
 
 [dependencies]
-aurora-engine-precompiles = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.6.1", features = ["std"] }
-aurora-engine-sdk = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.6.1", features = ["std"] }
-aurora-engine-transactions = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.6.1", features = ["std"] }
-aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.6.1", features = ["std", "impl-serde"] }
+aurora-engine-precompiles = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.6.3", features = ["std"] }
+aurora-engine-sdk = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.6.3", features = ["std"] }
+aurora-engine-transactions = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.6.3", features = ["std"] }
+aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.6.3", features = ["std", "impl-serde"] }
 
 anyhow = "1"
+borsh = "1"
 bs58 = "0.5"
 clap = { version = "4", features = ["derive"] }
 ethabi = "18"
 hex = "0.4"
 lazy_static = "1"
 libsecp256k1 = { version = "0.7", features = ["std"] }
-near-chain-configs = { version = "0.20", optional = true }
-near-crypto = "0.20"
-near-jsonrpc-client = "0.8"
-near-jsonrpc-primitives = "0.20"
-near-primitives = "0.20"
-reqwest = { version = "0.11", features = ["json"] }
+near-chain-configs = { version = "0.23", optional = true }
+near-crypto = "0.23"
+near-jsonrpc-client = "0.10"
+near-jsonrpc-primitives = "0.23"
+near-primitives = "0.23"
+reqwest = { version = "0.12", features = ["json"] }
 rand = "0.8"
 rlp = "0.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = { version = "0.8", optional = true }
-shadow-rs = "0.27"
+shadow-rs = "0.29"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }
 
 [build-dependencies]
-shadow-rs = "0.27"
+shadow-rs = "0.29"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ on an Ethereum-compatible, high-throughput, scalable and future-safe platform, w
 for their users. Engine is the Aurora's implementation for it.
 
 ## What is Aurora CLI?
+
 Aurora CLI is a command line interface to bootstrap Aurora Engine with rapid speed built with rust.
 
 Aurora CLI comes pre-configuration with opinionated, sensible defaults for standard testing environments.
@@ -33,12 +34,13 @@ If other projects mention testing on Aurora, they are referring to the settings 
 See also prior version [aurora-cli](https://github.com/aurora-is-near/aurora-cli).
 
 ## Prerequisites
+
 - :crab: Rust
 
 ## Quickstart
 
-- 📦 Install `aurora-cli-rs` and start interacting with it: 
-    *`cargo install --git https://github.com/aurora-is-near/aurora-cli-rs.git`* 
+- 📦 Install `aurora-cli-rs` and start interacting with it:
+  *`cargo install --git https://github.com/aurora-is-near/aurora-cli-rs.git`*
 - 🔍 Check out what each command is for in the official Aurora [docs](https://doc.aurora.dev/tools/aurora-cli)
 - ✋ Have questions? Ask them at the official Aurora [forum](https://forum.aurora.dev/)
 
@@ -48,12 +50,14 @@ In the following example, we will see how to deploy Aurora EVM on the `localnet`
 smart contract and will be interacting with it.
 
 ### **Requirements**
-- Rust 1.68.0 or newer
+
+- Rust 1.75.0 or newer
 - Python3
 
 First what we need to do is to install `aurora-cli`:
 
 ### **Installing aurora-cli**
+
 ```shell
 git clone https://github.com/aurora-engine/aurora-cli-rs
 cd aurora-cli-rs && cargo install --path . 
@@ -62,39 +66,48 @@ cd aurora-cli-rs && cargo install --path .
 Next we need to start a NEAR node locally. We can use the NEAR utility, `nearup`.
 
 ### **Start a NEAR node locally**
+
 Install `nearup`:
+
 ```shell
 pip3 install --user nearup
 ```
 
 Start NEAR node:
+
 ```shell
 nearup run localnet --home /tmp/localnet
 ```
 
 ### **Prepare an account and create a private key file for Aurora EVM**
+
 ```shell
 aurora-cli --near-key-path /tmp/localnet/node0/validator_key.json create-account \
   --account aurora.node0 --balance 100 > /tmp/localnet/aurora_key.json
 ```
 
 Let's check if the account has been created successfully:
+
 ```shell
 aurora-cli view-account aurora.node0
 ```
 
 ### **Download and deploy Aurora EVM**
+
 To download the latest version, run the following command:
+
 ```shell
 curl -sL https://github.com/aurora-is-near/aurora-engine/releases/download/latest/aurora-mainnet.wasm -o /tmp/aurora-mainnet.wasm
 ```
 
 Deploy Aurora EVM:
+
 ```shell
 aurora-cli --near-key-path /tmp/localnet/aurora_key.json deploy-aurora /tmp/aurora-mainnet.wasm
 ```
 
 Initialize Aurora EVM:
+
 ```shell
 aurora-cli --engine aurora.node0 --near-key-path /tmp/localnet/aurora_key.json init --chain-id 1313161556 --owner-id aurora.node0
 ```
@@ -105,19 +118,24 @@ And now we can deploy the EVM smart contract. In our example, it will be a simpl
 value and increment and decrement its value.
 
 But before that we need to generate a private key for signing transactions:
+
 ```shell
 aurora-cli key-pair --random
 ```
+
 The response should be similar to this:
+
 ```json
 {
   "address": "0xa003a6e0e1a1dc40aa9e496c1c058b2667c409f5",
   "secret_key": "3fac6dca1c6fc056b971a4e9090afbbfbdf3bc443e9cda595facb653cb1c01e1"
 }
 ```
-**_NOTE:_** The key should be used for demonstration only. 
+
+**_NOTE:_** The key should be used for demonstration only.
 
 Deploy EVM smart contract:
+
 ```shell
 aurora-cli --engine aurora.node0 --near-key-path /tmp/localnet/aurora_key.json deploy \
   --code $(cat docs/res/Counter.hex) \
@@ -125,10 +143,13 @@ aurora-cli --engine aurora.node0 --near-key-path /tmp/localnet/aurora_key.json d
   --args '{"init_value":"5"}' \
   --aurora-secret-key 3fac6dca1c6fc056b971a4e9090afbbfbdf3bc443e9cda595facb653cb1c01e1
 ```
+
 If everything went well, the response should be like this:
+
 ```
 Contract has been deployed to address: 0x53a9fed853e02a39bf8d298f751374de8b5a6ddf successfully
 ```
+
 So. Now we have deployed the smart contract at address: `0x53a9fed853e02a39bf8d298f751374de8b5a6ddf`.
 
 ### **Interact with the smart contract**
@@ -136,13 +157,16 @@ So. Now we have deployed the smart contract at address: `0x53a9fed853e02a39bf8d2
 First, let's check that the current value is the same as we set in the
 initialization stage. For that, we will use the `view-call` operation, which doesn't demand a private key
 because it is a read-only operation:
+
 ```shell
 aurora-cli --engine aurora.node0 view-call -a 0x53a9fed853e02a39bf8d298f751374de8b5a6ddf -f value \
   --abi-path docs/res/Counter.abi
 ```
+
 If we see `5` then everything is right.
 
 Now let's try to increment the value:
+
 ```shell
 aurora-cli --engine aurora.node0 --near-key-path /tmp/localnet/aurora_key.json call \
   --address 0x53a9fed853e02a39bf8d298f751374de8b5a6ddf \
@@ -150,22 +174,27 @@ aurora-cli --engine aurora.node0 --near-key-path /tmp/localnet/aurora_key.json c
   --abi-path docs/res/Counter.abi \
   --aurora-secret-key 3fac6dca1c6fc056b971a4e9090afbbfbdf3bc443e9cda595facb653cb1c01e1
 ```
+
 In the response, we can see if the transaction was successful and the amount of gas used for the execution of this
 transaction.
 
 Let's make sure that our value was incremented:
+
 ```shell
 aurora-cli --engine aurora.node0 view-call -a 0x53a9fed853e02a39bf8d298f751374de8b5a6ddf -f value \
   --abi-path docs/res/Counter.abi
 ```
+
 So, if we can see `6` in the output then the demo was successful. That's it!
 
 ### **Build aurora-cli with the advanced command line interface (Advanced CLI)**
 
 Advanced CLI provides more options andadvanced features. You can try it by building with the following command:
+
 ```shell
 cargo install --path . --no-default-features -F advanced
 ```
+
 Documentation on how to work with the advanced version of `aurora-cli` can be found [here](docs/localnet.md).
 
 ### **Browse Deployed EVM Metadata**
@@ -188,44 +217,59 @@ aurora-cli --engine aurora.node0 get-storage-at --address 0x53a9fed853e02a39bf8d
 
 ### **Silo methods**
 
-Retrieves the current fixed gas set in the Silo contract. 
+Retrieves the current fixed gas set in the Silo contract.
+
 ```shell
 aurora-cli --engine aurora.node0 get-fixed-gas
 ```
+
 Sets the fixed gas in the Silo contract to a specific value.
+
 ```shell
 aurora-cli --engine aurora.node0 set-fixed-gas 0
 ```
+
 Check whitelists statuses
+
 ```shell
 aurora-cli --engine aurora.node0 get-whitelist-status admin
 aurora-cli --engine aurora.node0 get-whitelist-status evm-admin
 aurora-cli --engine aurora.node0 get-whitelist-status account
 aurora-cli --engine aurora.node0 get-whitelist-status address
 ```
+
 Add whitelist entry
+
 ```shell
 aurora-cli --engine aurora.node0 add-entry-to-whitelist --kind <whitelist-kind> --entry <entry-value>
 ```
+
 Remove whitelist entry
+
 ```shell
 aurora-cli --engine aurora.node0 remove-entry-from-whitelist --kind <whitelist-kind> --entry <entry-value>
 ```
+
 Disable whitelist status
+
 ```shell
 aurora-cli --engine aurora.node0 set-whitelist-status --kind <whitelist-kind> --status 0
 ```
-Replace `<whitelist-kind>` with the desired whitelist type (admin, evm-admin, account, or address), and `<entry-value>` with the address or account to be whitelisted or removed.
 
+Replace `<whitelist-kind>` with the desired whitelist type (admin, evm-admin, account, or address), and `<entry-value>`
+with the address or account to be whitelisted or removed.
 
 Add whitelist batch
+
 ```shell
 aurora-cli --engine aurora.node0 add-entry-to-whitelist-batch path/to/batch_list.json
 ```
 
-The batch should be provided in a JSON format. Each entry in the JSON array should have two properties: `kind` and either `account_id` or `address`, depending on the type of whitelist being updated.
+The batch should be provided in a JSON format. Each entry in the JSON array should have two properties: `kind` and
+either `account_id` or `address`, depending on the type of whitelist being updated.
 
 Example JSON batch file (`batch_list.json`):
+
 ```json
 [
   {
@@ -270,8 +314,10 @@ Example JSON batch file (`batch_list.json`):
 - [`aurora-cli resume-precompiles`](#aurora-cli-resume-precompiles)
 - [`aurora-cli paused-precompiles`](#aurora-cli-paused-precompiles)
 - [`aurora-cli factory-update`](#aurora-cli-factory-update)
+- [`aurora-cli factory-get-wnear-address`](#aurora-cli-factory-get-wnear-address)
 - [`aurora-cli factory-set-wnear-address`](#aurora-cli-factory-set-wnear-address)
 - [`aurora-cli fund-xcc-sub-account`](#aurora-cli-fund-xcc-sub-account)
+- [`aurora-cli upgrade`](#aurora-cli-upgrade)
 - [`aurora-cli stage-upgrade`](#aurora-cli-stage-upgrade)
 - [`aurora-cli deploy-upgrade`](#aurora-cli-deploy-upgrade)
 - [`aurora-cli deploy`](#aurora-cli-deploy)
@@ -279,22 +325,30 @@ Example JSON batch file (`batch_list.json`):
 - [`aurora-cli call`](#aurora-cli-call)
 - [`aurora-cli encode-address`](#aurora-cli-encode-address)
 - [`aurora-cli key-pair`](#aurora-cli-key-pair)
+- [`aurora-cli generate-near-key`](#aurora-cli-generate-near-key)
+- [`aurora-cli get-fixed-gas`](#aurora-cli-get-fixed-gas)
+- [`aurora-cli set-fixed-gas`](#aurora-cli-set-fixed-gas)
+- [`aurora-cli set-silo-params`](#aurora-cli-set-silo-params)
 - [`aurora-cli get-whitelist-status`](#aurora-cli-get-whitelist-status)
 - [`aurora-cli set-whitelist-status`](#aurora-cli-set-whitelist-status)
 - [`aurora-cli add-entry-to-whitelist`](#aurora-cli-add-entry-to-whitelist)
 - [`aurora-cli add-entry-to-whitelist-batch`](#aurora-cli-add-entry-to-whitelist-batch)
 - [`aurora-cli remove-entry-from-whitelist`](#aurora-cli-remove-entry-from-whitelist)
-- [`aurora-cli set-key-manager`](#aurora-cli-set-key-manager)  
+- [`aurora-cli set-key-manager`](#aurora-cli-set-key-manager)
 - [`aurora-cli add-relayer-key`](#aurora-cli-add-relayer-key)
-- [`aurora-cli remove-relayer-key`](#aurora-cli-remove-relayer-key)       
-- [`aurora-cli get-upgrade-delay-blocks`](#aurora-cli-get-upgrade-delay-blocks) 
-- [`aurora-cli set-upgrade-delay-blocks`](#aurora-cli-set-upgrade-delay-blocks) 
-- [`aurora-cli get-erc20-from-nep141`](#aurora-cli-get-erc20-from-nep141)    
-- [`aurora-cli get-nep141-from-erc20`](#aurora-cli-get-nep141-from-erc20)    
+- [`aurora-cli remove-relayer-key`](#aurora-cli-remove-relayer-key)
+- [`aurora-cli get-upgrade-delay-blocks`](#aurora-cli-get-upgrade-delay-blocks)
+- [`aurora-cli set-upgrade-delay-blocks`](#aurora-cli-set-upgrade-delay-blocks)
+- [`aurora-cli get-erc20-from-nep141`](#aurora-cli-get-erc20-from-nep141)
+- [`aurora-cli get-nep141-from-erc20`](#aurora-cli-get-nep141-from-erc20)
 - [`aurora-cli get-erc20-metadata`](#aurora-cli-get-erc20-metadata)
-- [`aurora-cli set-erc20-metadata`](#aurora-cli-set-erc20-metadata)    
+- [`aurora-cli set-erc20-metadata`](#aurora-cli-set-erc20-metadata)
 - [`aurora-cli mirror-erc20-token`](#aurora-cli-mirror-erc20-token)
-- [`aurora-cli set-eth-connector-account-id`](#aurora-cli-set-eth-connector-account-id)
+- [`aurora-cli set-eth-connector-contract-account`](#aurora-cli-set-eth-connector-contract-account)
+- [`aurora-cli get-eth-connector-contract-account`](#aurora-cli-get-eth-connector-contract-account)
+- [`aurora-cli set-eth-connector-contract-data`](#aurora-cli-set-eth-connector-contract-data)
+- [`aurora-cli get-paused_flags`](#aurora-cli-get-paused-flags)
+- [`aurora-cli set-paused_flags`](#aurora-cli-set-paused-flags)
 
 ### `aurora-cli help`
 
@@ -305,54 +359,62 @@ Simple command line interface for communication with Aurora Engine
 Usage: aurora-cli [OPTIONS] <COMMAND>
 
 Commands:
-  create-account                Create new NEAR account
-  view-account                  View NEAR account
-  deploy-aurora                 Deploy Aurora EVM smart contract
-  init                          Initialize Aurora EVM and ETH connector
-  get-chain-id                  Return chain id of the network
-  get-nonce                     Return next nonce for address
-  get-block-hash                Return block hash of the specified height
-  get-code                      Return smart contract's code for contract address
-  get-balance                   Return balance for address
-  get-upgrade-index             Return a height for a staged upgrade
-  get-version                   Return Aurora EVM version
-  get-owner                     Return Aurora EVM owner
-  set-owner                     Set a new owner of Aurora EVM
-  get-bridge-prover             Return bridge prover
-  get-storage-at                Return a value from storage at address with key
-  register-relayer              Register relayer address
-  pause-precompiles             Pause precompiles
-  resume-precompiles            Resume precompiles
-  paused-precompiles            Return paused precompiles
-  factory-update                Updates the bytecode for user's router contracts
-  factory-set-wnear-address     Sets the address for the `wNEAR` ERC-20 contract
-  fund-xcc-sub-account          Create and/or fund an XCC sub-account directly
-  stage-upgrade                 Stage a new code for upgrade
-  deploy-upgrade                Deploy staged upgrade
-  deploy                        Deploy EVM smart contract's code in hex
-  view-call                     Call a view method of the smart contract
-  call                          Call a modified method of the smart contract
-  encode-address                Encode address
-  key-pair                      Return Public and Secret ED25519 keys
-  get-fixed-gas                 Return fixed gas per transaction
-  set-fixed-gas                 Set fixed gas per transaction
-  get-whitelist-status          Return a status of the whitelist
-  set-whitelist-status          Set a status for the whitelist
-  add-entry-to-whitelist        Add entry into the whitelist
-  add-entry-to-whitelist-batch  Add entries into the whitelist
-  remove-entry-from-whitelist   Remove the entry from the whitelist
-  set-key-manager               Set relayer key manager
-  add-relayer-key               Add relayer public key
-  remove-relayer-key            Remove relayer public key
-  get-upgrade-delay-blocks      Get delay for upgrade in blocks
-  set-upgrade-delay-blocks      Set delay for upgrade in blocks
-  get-erc20-from-nep141         Get ERC-20 from NEP-141
-  get-nep141-from-erc20         Get NEP-141 from ERC-20
-  get-erc20-metadata            Get ERC-20 metadata
-  set-erc20-metadata            Set ERC-20 metadata
-  mirror-erc20-token            Mirror ERC-20 token
-  set-eth-connector-account-id  Set eth connector account id
-  help                          Print this message or the help of the given subcommand(s)
+  create-account                      Create new NEAR account
+  view-account                        View NEAR account
+  deploy-aurora                       Deploy Aurora EVM smart contract
+  init                                Initialize Aurora EVM and ETH connector
+  get-chain-id                        Return chain id of the network
+  get-nonce                           Return next nonce for address
+  get-block-hash                      Return block hash of the specified height
+  get-code                            Return smart contract's code for contract address
+  get-balance                         Return balance for address
+  get-upgrade-index                   Return a height for a staged upgrade
+  get-version                         Return Aurora EVM version
+  get-owner                           Return Aurora EVM owner
+  set-owner                           Set a new owner of Aurora EVM
+  get-bridge-prover                   Return bridge prover
+  get-storage-at                      Return a value from storage at address with key
+  register-relayer                    Register relayer address
+  pause-precompiles                   Pause precompiles
+  resume-precompiles                  Resume precompiles
+  paused-precompiles                  Return paused precompiles
+  factory-update                      Updates the bytecode for user's router contracts
+  factory-get-wnear-address           Return the address of the `wNEAR` ERC-20 contract
+  factory-set-wnear-address           Sets the address for the `wNEAR` ERC-20 contract
+  fund-xcc-sub-account                Create and/or fund an XCC sub-account directly
+  upgrade                             Upgrade contract with provided code
+  stage-upgrade                       Stage a new code for upgrade
+  deploy-upgrade                      Deploy staged upgrade
+  deploy                              Deploy EVM smart contract's code in hex
+  view-call                           Call a view method of the smart contract
+  call                                Call a modified method of the smart contract
+  encode-address                      Encode address
+  key-pair                            Return Public and Secret ED25519 keys
+  generate-near-key                   Return randomly generated NEAR key for AccountId
+  get-fixed-gas                       Return fixed gas
+  set-fixed-gas                       Set fixed gas
+  set-silo-params                     Set SILO params
+  get-whitelist-status                Return a status of the whitelist
+  set-whitelist-status                Set a status for the whitelist
+  add-entry-to-whitelist              Add entry into the whitelist
+  add-entry-to-whitelist-batch        Add entries into the whitelist
+  remove-entry-from-whitelist         Remove the entry from the whitelist
+  set-key-manager                     Set relayer key manager
+  add-relayer-key                     Add relayer public key
+  remove-relayer-key                  Remove relayer public key
+  get-upgrade-delay-blocks            Get delay for upgrade in blocks
+  set-upgrade-delay-blocks            Set delay for upgrade in blocks
+  get-erc20-from-nep141               Get ERC-20 from NEP-141
+  get-nep141-from-erc20               Get NEP-141 from ERC-20
+  get-erc20-metadata                  Get ERC-20 metadata
+  set-erc20-metadata                  Set ERC-20 metadata
+  mirror-erc20-token                  Mirror ERC-20 token
+  set-eth-connector-contract-account  Set eth connector account id
+  get-eth-connector-contract-account  Get eth connector account id
+  set-eth-connector-contract-data     Set eth connector data
+  set-paused-flags                    Set eth connector paused flags
+  get-paused-flags                    Get eth connector paused flags
+  help                                Print this message or the help of the given subcommand(s)
 
 Options:
       --network <NETWORK>              NEAR network ID [default: localnet]
@@ -654,6 +716,18 @@ Options:
   -h, --help  Print help
 ```
 
+### `aurora-cli factory-get-wnear-address`
+
+```console
+$ aurora-cli help factory-get-wnear-address
+Return the address of the `wNEAR` ERC-20 contract
+
+Usage: aurora-cli factory-get-wnear-address
+
+Options:
+  -h, --help  Print help
+```
+
 ### `aurora-cli factory-set-wnear-address`
 
 ```console
@@ -693,6 +767,21 @@ $ aurora-cli help stage-upgrade
 Stage a new code for upgrade
 
 Usage: aurora-cli stage-upgrade <PATH>
+
+Arguments:
+  <PATH>  
+
+Options:
+  -h, --help  Print help
+```
+
+### `aurora-cli upgrade`
+
+```console
+$ aurora-cli help upgrade
+Upgrade contract with provided code
+
+Usage: aurora-cli upgrade <PATH>
 
 Arguments:
   <PATH>  
@@ -748,7 +837,7 @@ Options:
 ### `aurora-cli call`
 
 ```console
-aurora-cli help call
+$ aurora-cli help call
 Call a modified method of the smart contract
 
 Usage: aurora-cli call [OPTIONS] --address <ADDRESS> --function <FUNCTION> --abi-path <ABI_PATH>
@@ -792,11 +881,62 @@ Options:
   -h, --help         Print help
 ```
 
-  Return a status of the whitelist
-  Set a status for the whitelist
-  Add entry into the whitelist
-  Add entries into the whitelist
-  Remove the entry from the whitelist
+### `aurora-cli generate-near-key`
+
+```console
+$ aurora-cli help generate-near-key
+Return randomly generated NEAR key for AccountId
+
+Usage: aurora-cli generate-near-key <ACCOUNT_ID> <KEY_TYPE>
+
+Arguments:
+  <ACCOUNT_ID>  AccountId
+  <KEY_TYPE>    Key type: ed25519 or secp256k1
+
+Options:
+  -h, --help  Print help
+```
+
+### `aurora-cli get-fixed-gas`
+
+```console
+$ aurora-cli help get-fixed-gas
+Return fixed gas
+
+Usage: aurora-cli get-fixed-gas
+
+Options:
+  -h, --help  Print help
+```
+
+### `aurora-cli set-fixed-gas`
+
+```console
+$ aurora-cli help set-fixed-gas
+Set fixed gas
+
+Usage: aurora-cli set-fixed-gas <COST>
+
+Arguments:
+  <COST>  Fixed gas in EthGas
+
+Options:
+  -h, --help  Print help
+```
+
+### `aurora-cli set-silo-params`
+
+```console
+$ aurora-cli help set-silo-params
+Set SILO params
+
+Usage: aurora-cli set-silo-params --gas <GAS> --fallback-address <FALLBACK_ADDRESS>
+
+Options:
+  -g, --gas <GAS>                            Fixed gas in EthGas
+  -f, --fallback-address <FALLBACK_ADDRESS>  Fallback EVM address
+  -h, --help                                 Print help
+```
 
 ### `aurora-cli get-whitelist-status`
 
@@ -830,7 +970,7 @@ Options:
 ### `aurora-cli add-entry-to-whitelist`
 
 ```console
-aurora-cli help add-entry-to-whitelist
+$ aurora-cli help add-entry-to-whitelist
 Add entry into the whitelist
 
 Usage: aurora-cli add-entry-to-whitelist --kind <KIND> --entry <ENTRY>
@@ -1016,16 +1156,74 @@ Options:
   -h, --help                       Print help
 ```
 
-### `aurora-cli set-eth-connector-account-id`
+### `aurora-cli set-eth-connector-contract-account`
 
 ```console
-$ aurora-cli help set-eth-connector-account-id 
+$ aurora-cli help set-eth-connector-contract-account
 Set eth connector account id
 
-Usage: aurora-cli set-eth-connector-account-id [OPTIONS] --account-id <ACCOUNT_ID>
+Usage: aurora-cli set-eth-connector-contract-account [OPTIONS] --account-id <ACCOUNT_ID>
 
 Options:
       --account-id <ACCOUNT_ID>      Account id of eth connector
       --withdraw-ser <WITHDRAW_SER>  Serialization type in withdraw method
+  -h, --help           
+```
+
+### `aurora-cli get-eth-connector-contract-account`
+
+```console
+$ aurora-cli help get-eth-connector-contract-account
+Get eth connector account id
+
+Usage: aurora-cli get-eth-connector-contract-account
+
+Options:
+  -h, --help  Print help
+```
+
+### `aurora-cli set-eth-connector-contract-data`
+
+```console
+$ aurora-cli help set-eth-connector-contract-data
+Set eth connector data
+
+Usage: aurora-cli set-eth-connector-contract-data --prover-id <PROVER_ID> --custodian-address <CUSTODIAN_ADDRESS> --ft-metadata-path <FT_METADATA_PATH>
+
+Options:
+      --prover-id <PROVER_ID>
+          Prover account id
+      --custodian-address <CUSTODIAN_ADDRESS>
+          Custodian ETH address
+      --ft-metadata-path <FT_METADATA_PATH>
+          Path to the file with the metadata of the fungible token
   -h, --help
+          Print help
+```
+
+### `aurora-cli set-paused-flags`
+
+```console
+$ aurora-cli help set-paused-flags
+Set eth connector paused flags
+
+Usage: aurora-cli set-paused-flags <MASK>
+
+Arguments:
+  <MASK>  Pause mask
+
+Options:
+  -h, --help  Print help
+```
+
+### `aurora-cli get-paused-flags`
+
+```console
+$ aurora-cli help get-paused-flags
+Get eth connector paused flags
+
+Usage: aurora-cli get-paused-flags
+
+Options:
+  -h, --help  Print help
 ```

--- a/scripts/advanced.sh
+++ b/scripts/advanced.sh
@@ -42,10 +42,14 @@ error_exit() {
   finish 1
 }
 
+wait_for_block() {
+  sleep 1.5
+}
+
 # Download `neard` and preparing config files.
 start_node
 nearup stop > /dev/null 2>&1
-sleep 2
+wait_for_block
 
 # Update configs and add aurora key.
 aurora-cli near init genesis --path $NEARCORE_HOME/node0/genesis.json
@@ -54,18 +58,18 @@ aurora-cli near init local-config -n $NEARCORE_HOME/node0/config.json -a $NEARCO
 # Start NEAR node.
 rm -rf $NEARCORE_HOME/node0/data
 start_node
-sleep 1
+wait_for_block
 
 # Download Aurora EVM.
 curl -sL $ENGINE_WASM_URL -o $ENGINE_WASM_PATH || error_exit
 
 # Deploy and init Aurora EVM smart contract.
 aurora-cli near write engine-init -w $ENGINE_WASM_PATH || error_exit
-sleep 2
+wait_for_block
 
 # Deploy EVM code.
 aurora-cli near write deploy-code $EVM_CODE || error_exit
-sleep 2
+wait_for_block
 
 # Run EVM view call.
 aurora-cli near read solidity -t 0x592186c059e3d9564cac6b1ada6f2dc7ff1d78e9 call-args-by-name \

--- a/scripts/simple-silo.sh
+++ b/scripts/simple-silo.sh
@@ -56,6 +56,10 @@ assert_eq() {
   fi
 }
 
+wait_for_block() {
+  sleep 1.5
+}
+
 # Start NEAR node.
 start_node
 sleep 2
@@ -63,11 +67,11 @@ sleep 2
 export NEAR_KEY_PATH=$NODE_KEY_PATH
 # Create an account for Aurora EVM.
 aurora-cli create-account --account $ENGINE_ACCOUNT --balance 100 > $AURORA_KEY_PATH || error_exit
-sleep 1
+wait_for_block
 
 # View info of created account.
 aurora-cli view-account $ENGINE_ACCOUNT || error_exit
-sleep 1
+wait_for_block
 
 # Deploy Aurora EVM.
 export NEAR_KEY_PATH=$AURORA_KEY_PATH
@@ -90,7 +94,7 @@ assert_eq "none" "$result"
 # Set fixed gas
 aurora-cli --engine $ENGINE_ACCOUNT set-silo-params --gas 0 --fallback-address \
   0x7e5f4552091a69125d5dfcb7b8c2659029395bdf || error_exit
-sleep 1
+wait_for_block
 # Get fixed gas
 result=$(aurora-cli --engine $ENGINE_ACCOUNT get-fixed-gas || error_exit)
 assert_eq "0" "$result"
@@ -107,83 +111,83 @@ assert_eq "1" "$result"
 
 # Add whitelist batch
 aurora-cli --engine $ENGINE_ACCOUNT add-entry-to-whitelist-batch docs/res/batch_list.json || error_exit
-sleep 1
+wait_for_block
 
 # Add address into EvmAdmin whitelist to allow deploy EVM code
 aurora-cli --engine $ENGINE_ACCOUNT add-entry-to-whitelist --kind evm-admin \
   --entry 0xF388d9622737637cf0a80Bbd378e0b4D797a87c9 || error_exit
-sleep 1
+wait_for_block
 # Add account into Admin whitelist to allow deploy EVM code
 aurora-cli --engine $ENGINE_ACCOUNT add-entry-to-whitelist --kind admin --entry $ENGINE_ACCOUNT || error_exit
-sleep 1
+wait_for_block
 
 # Deploy Counter EVM code.
 aurora-cli --engine $ENGINE_ACCOUNT deploy --code $EVM_CODE --abi-path $ABI_PATH --args '{"init_value":"5"}' \
   --aurora-secret-key $AURORA_SECRET_KEY || error_exit
-sleep 1
+wait_for_block
 result=$(aurora-cli --engine $ENGINE_ACCOUNT view-call -a 0xa3078bf607d2e859dca0b1a13878ec2e607f30de -f value \
   --abi-path $ABI_PATH || error_exit)
 assert_eq "$result" "5"
-sleep 1
+wait_for_block
 
 # Add address into Address whitelist to allow submit transactions
 aurora-cli --engine $ENGINE_ACCOUNT add-entry-to-whitelist --kind address \
   --entry 0x04B678962787cCD195a8e324d4C6bc4d5727F82B || error_exit
-sleep 1
+wait_for_block
 
 # Add account into Account whitelist to allow submit transactions
 aurora-cli --engine $ENGINE_ACCOUNT add-entry-to-whitelist --kind account --entry $ENGINE_ACCOUNT || error_exit
-sleep 1
+wait_for_block
 
 # Submit increment transactions
 aurora-cli --engine $ENGINE_ACCOUNT call -a 0xa3078bf607d2e859dca0b1a13878ec2e607f30de -f increment \
   --abi-path $ABI_PATH \
   --aurora-secret-key 611830d3641a68f94a690dcc25d1f4b0dac948325ac18f6dd32564371735f32c || error_exit
-sleep 1
+sleep 2
 
 # Check result
 result=$(aurora-cli --engine $ENGINE_ACCOUNT view-call -a 0xa3078bf607d2e859dca0b1a13878ec2e607f30de -f value \
   --abi-path $ABI_PATH || error_exit)
 assert_eq "$result" "6"
-sleep 1
+wait_for_block
 
 # Submit decrement transaction
 aurora-cli --engine $ENGINE_ACCOUNT call -a 0xa3078bf607d2e859dca0b1a13878ec2e607f30de -f decrement \
   --abi-path $ABI_PATH \
   --aurora-secret-key 611830d3641a68f94a690dcc25d1f4b0dac948325ac18f6dd32564371735f32c || error_exit
-sleep 1
+wait_for_block
 
 # Check result
 result=$(aurora-cli --engine $ENGINE_ACCOUNT view-call -a 0xa3078bf607d2e859dca0b1a13878ec2e607f30de -f value \
   --abi-path $ABI_PATH || error_exit)
 assert_eq "$result" "5"
-sleep 1
+wait_for_block
 
 # Remove entries from Account and Address whitelists.
 aurora-cli --engine $ENGINE_ACCOUNT remove-entry-from-whitelist --kind address \
   --entry 0x04B678962787cCD195a8e324d4C6bc4d5727F82B || error_exit
-sleep 1
+wait_for_block
 
 aurora-cli --engine $ENGINE_ACCOUNT remove-entry-from-whitelist --kind account --entry $ENGINE_ACCOUNT || error_exit
-sleep 1
+wait_for_block
 
 # Disable Account and Address whitelists to allow to submit transactions to anyone.
 aurora-cli --engine $ENGINE_ACCOUNT set-whitelist-status --kind account --status 0 || error_exit
-sleep 1
+wait_for_block
 aurora-cli --engine $ENGINE_ACCOUNT set-whitelist-status --kind address --status 0 || error_exit
-sleep 1
+wait_for_block
 
 # Submit decrement transaction
 aurora-cli --engine $ENGINE_ACCOUNT call -a 0xa3078bf607d2e859dca0b1a13878ec2e607f30de -f decrement \
   --abi-path $ABI_PATH \
   --aurora-secret-key 591f4a18a51779f76ecb5943cb6b6e73bf5877520511b7209a342c176295805b || error_exit
-sleep 1
+wait_for_block
 
 # Check result
 result=$(aurora-cli --engine $ENGINE_ACCOUNT view-call -a 0xa3078bf607d2e859dca0b1a13878ec2e607f30de -f value \
   --abi-path $ABI_PATH || error_exit)
 assert_eq "$result" "4"
-sleep 1
+wait_for_block
 
 # Stop NEAR node and clean up.
 finish

--- a/scripts/simple.sh
+++ b/scripts/simple.sh
@@ -67,9 +67,13 @@ assert_eq() {
   fi
 }
 
+wait_for_block() {
+  sleep 1.5
+}
+
 # Start NEAR node.
 start_node
-sleep 1
+wait_for_block
 
 # Download Aurora EVM.
 curl -sL $ENGINE_PREV_WASM_URL -o $ENGINE_WASM_PATH || error_exit
@@ -77,11 +81,11 @@ curl -sL $ENGINE_PREV_WASM_URL -o $ENGINE_WASM_PATH || error_exit
 export NEAR_KEY_PATH=$NODE_KEY_PATH
 # Create an account for Aurora EVM.
 aurora-cli create-account --account $ENGINE_ACCOUNT --balance 100 > $AURORA_KEY_PATH || error_exit
-sleep 1
+wait_for_block
 
 # View info of created account.
 aurora-cli view-account $ENGINE_ACCOUNT || error_exit
-sleep 1
+wait_for_block
 
 # Deploy Aurora EVM.
 export NEAR_KEY_PATH=$AURORA_KEY_PATH
@@ -95,7 +99,7 @@ aurora-cli --engine $ENGINE_ACCOUNT init \
   --upgrade-delay-blocks 1 \
   --custodian-address 0x1B16948F011686AE64BB2Ba0477aeFA2Ea97084D \
   --ft-metadata-path docs/res/ft_metadata.json || error_exit
-sleep 2
+wait_for_block
 
 # Upgrading Aurora EVM to the latest.
 version=$(aurora-cli --engine $ENGINE_ACCOUNT get-version || error_exit)
@@ -103,9 +107,9 @@ assert_eq "$version" $AURORA_PREV_VERSION
 echo "$version"
 curl -sL $ENGINE_LAST_WASM_URL -o $ENGINE_WASM_PATH || error_exit
 aurora-cli --engine $ENGINE_ACCOUNT stage-upgrade $ENGINE_WASM_PATH || error_exit
-sleep 2
+wait_for_block
 aurora-cli --engine $ENGINE_ACCOUNT deploy-upgrade || error_exit
-sleep 1
+wait_for_block
 version=$(aurora-cli --engine $ENGINE_ACCOUNT get-version || error_exit)
 assert_eq "$version" $AURORA_LAST_VERSION
 echo "$version"
@@ -113,15 +117,15 @@ echo "$version"
 # Modify eth connector data
 aurora-cli --engine $ENGINE_ACCOUNT set-eth-connector-contract-data --prover-id "another.prover" \
   --custodian-address "0xa3078bf607d2e859dca0b1a13878ec2e607f30de" --ft-metadata-path docs/res/ft_metadata.json || error_exit
-sleep 1
+wait_for_block
 
 # Create account id for key manager
 aurora-cli create-account --account $MANAGER_ACCOUNT --balance 10 > $MANAGER_KEY_PATH || error_exit
-sleep 1
+wait_for_block
 
 # Set key manager
 aurora-cli --engine $ENGINE_ACCOUNT set-key-manager $MANAGER_ACCOUNT || error_exit
-sleep 1
+wait_for_block
 
 # Create new keys for relayer
 aurora-cli generate-near-key $ENGINE_ACCOUNT ed25519 > $RELAYER_KEY_PATH || error_exit
@@ -130,21 +134,21 @@ relayer_public_key="$(jq -r .public_key < $RELAYER_KEY_PATH)"
 # Add relayer key by key manager
 export NEAR_KEY_PATH=$MANAGER_KEY_PATH
 aurora-cli --engine $ENGINE_ACCOUNT add-relayer-key --public-key "$relayer_public_key" --allowance "0.5" || error_exit
-sleep 1
+wait_for_block
 
 # Deploy Hello World EVM code with relayer key.
 export NEAR_KEY_PATH=$RELAYER_KEY_PATH
 aurora-cli --engine $ENGINE_ACCOUNT deploy --code "$EVM_CODE" --aurora-secret-key $AURORA_SECRET_KEY || error_exit
-sleep 1
+wait_for_block
 result=$(aurora-cli --engine $ENGINE_ACCOUNT view-call -a 0xa3078bf607d2e859dca0b1a13878ec2e607f30de -f greet \
   --abi-path $ABI_PATH || error_exit)
 assert_eq "$result" "Hello, World!"
-sleep 1
+wait_for_block
 
 # Remove relayer key
 export NEAR_KEY_PATH=$MANAGER_KEY_PATH
 aurora-cli --engine $ENGINE_ACCOUNT remove-relayer-key "$relayer_public_key" || error_exit
-sleep 1
+wait_for_block
 
 # Deploy Counter EVM code.
 export NEAR_KEY_PATH=$AURORA_KEY_PATH
@@ -152,27 +156,27 @@ EVM_CODE=$(cat docs/res/Counter.hex)
 ABI_PATH=docs/res/Counter.abi
 aurora-cli --engine $ENGINE_ACCOUNT deploy --code $EVM_CODE --abi-path $ABI_PATH --args '{"init_value":"5"}' \
   --aurora-secret-key $AURORA_SECRET_KEY || error_exit
-sleep 1
+wait_for_block
 result=$(aurora-cli --engine $ENGINE_ACCOUNT view-call -a 0x4cf003049d1a9c4918c73e9bf62464d904184555 -f value \
   --abi-path $ABI_PATH || error_exit)
 assert_eq "$result" "5"
-sleep 1
+wait_for_block
 aurora-cli --engine $ENGINE_ACCOUNT call -a 0x4cf003049d1a9c4918c73e9bf62464d904184555 -f increment \
   --abi-path $ABI_PATH \
   --aurora-secret-key 611830d3641a68f94a690dcc25d1f4b0dac948325ac18f6dd32564371735f32c || error_exit
-sleep 1
+wait_for_block
 result=$(aurora-cli --engine $ENGINE_ACCOUNT view-call -a 0x4cf003049d1a9c4918c73e9bf62464d904184555 -f value \
   --abi-path $ABI_PATH || error_exit)
 assert_eq "$result" "6"
-sleep 1
+wait_for_block
 aurora-cli --engine $ENGINE_ACCOUNT call -a 0x4cf003049d1a9c4918c73e9bf62464d904184555 -f decrement \
   --abi-path $ABI_PATH \
   --aurora-secret-key 611830d3641a68f94a690dcc25d1f4b0dac948325ac18f6dd32564371735f32c || error_exit
-sleep 1
+wait_for_block
 result=$(aurora-cli --engine $ENGINE_ACCOUNT view-call -a 0x4cf003049d1a9c4918c73e9bf62464d904184555 -f value \
   --abi-path $ABI_PATH || error_exit)
 assert_eq "$result" "5"
-sleep 1
+wait_for_block
 
 # Check read operations.
 aurora-cli --engine $ENGINE_ACCOUNT get-chain-id || error_exit
@@ -186,16 +190,16 @@ assert_eq "$block_hash" "0xd31857e9ce14083a7a74092b71f9ac48b8c0d4988ad40074182c1
 
 # Register a new relayer address
 aurora-cli --engine $ENGINE_ACCOUNT register-relayer 0xf644ad75e048eaeb28844dd75bd384984e8cd508 || error_exit
-sleep 1
+wait_for_block
 
 # Set a new owner. The functionality has not been released yet.
 aurora-cli --engine $ENGINE_ACCOUNT set-owner node0 || error_exit
-sleep 1
+wait_for_block
 owner=$(aurora-cli --engine $ENGINE_ACCOUNT get-owner || error_exit)
 assert_eq "$owner" node0
 export NEAR_KEY_PATH=$NODE_KEY_PATH
 aurora-cli --engine $ENGINE_ACCOUNT set-owner aurora.node0 || error_exit
-sleep 1
+wait_for_block
 owner=$(aurora-cli --engine $ENGINE_ACCOUNT get-owner || error_exit)
 assert_eq "$owner" $ENGINE_ACCOUNT
 
@@ -205,15 +209,15 @@ export NEAR_KEY_PATH=$AURORA_KEY_PATH
 mask=$(aurora-cli --engine $ENGINE_ACCOUNT paused-precompiles || error_exit)
 assert_eq "$mask" 0
 aurora-cli --engine $ENGINE_ACCOUNT pause-precompiles 1 || error_exit
-sleep 1
+wait_for_block
 mask=$(aurora-cli --engine $ENGINE_ACCOUNT paused-precompiles || error_exit)
 assert_eq "$mask" 1
 aurora-cli --engine $ENGINE_ACCOUNT pause-precompiles 2 || error_exit
-sleep 1
+wait_for_block
 mask=$(aurora-cli --engine $ENGINE_ACCOUNT paused-precompiles || error_exit)
 assert_eq "$mask" 3
 aurora-cli --engine $ENGINE_ACCOUNT resume-precompiles 3 || error_exit
-sleep 1
+wait_for_block
 mask=$(aurora-cli --engine $ENGINE_ACCOUNT paused-precompiles || error_exit)
 assert_eq "$mask" 0
 
@@ -221,16 +225,16 @@ assert_eq "$mask" 0
 # Download XCC router contract.
 curl -sL $XCC_ROUTER_LAST_WASM_URL -o $XCC_ROUTER_WASM_PATH || error_exit
 aurora-cli --engine $ENGINE_ACCOUNT factory-update $XCC_ROUTER_WASM_PATH || error_exit
-sleep 1
+wait_for_block
 aurora-cli --engine $ENGINE_ACCOUNT factory-set-wnear-address 0x80c6a002756e29b8bf2a587f7d975a726d5de8b9 || error_exit
-sleep 1
+wait_for_block
 aurora-cli --engine $ENGINE_ACCOUNT fund-xcc-sub-account 0x43a4969cc2c22d0000c591ff4bd71983ea8a8be9 some_account.near 25.5 || error_exit
 
 # Change upgrade delay blocks.
 blocks=$(aurora-cli --engine $ENGINE_ACCOUNT get-upgrade-delay-blocks || error_exit)
 assert_eq "$blocks" 1 # 1 is set on init stage
 aurora-cli --engine $ENGINE_ACCOUNT set-upgrade-delay-blocks 5 || error_exit
-sleep 1
+wait_for_block
 blocks=$(aurora-cli --engine $ENGINE_ACCOUNT get-upgrade-delay-blocks || error_exit)
 assert_eq "$blocks" 5
 

--- a/src/cli/advanced/near.rs
+++ b/src/cli/advanced/near.rs
@@ -15,6 +15,7 @@ use aurora_engine_types::{
     H256, U256,
 };
 use clap::Subcommand;
+use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::{
     account::{AccessKey, Account},
     hash::CryptoHash,
@@ -652,7 +653,14 @@ pub async fn execute_command(
                 };
                 let aurora_account_record = StateRecord::Account {
                     account_id: aurora_id.clone(),
-                    account: Account::new(aurora_amount, 0, CryptoHash::default(), 0),
+                    account: Account::new(
+                        aurora_amount,
+                        0,
+                        0,
+                        CryptoHash::default(),
+                        0,
+                        PROTOCOL_VERSION,
+                    ),
                 };
                 records.0.push(aurora_key_record);
                 records.0.push(aurora_account_record);

--- a/src/cli/advanced/near.rs
+++ b/src/cli/advanced/near.rs
@@ -2,7 +2,7 @@ use crate::{
     config::{Config, Network},
     utils,
 };
-use aurora_engine_types::borsh::{BorshDeserialize, BorshSerialize};
+use aurora_engine_types::borsh::BorshDeserialize;
 use aurora_engine_types::parameters::connector::{InitCallArgs, PauseEthConnectorCallArgs};
 use aurora_engine_types::parameters::engine::{
     DeployErc20TokenArgs, GetStorageAtArgs, NewCallArgs, NewCallArgsV2, SubmitResult,
@@ -342,7 +342,7 @@ pub async fn execute_command(
                         sender,
                         aurora_engine_precompiles::xcc::cross_contract_call::ADDRESS,
                         Wei::zero(),
-                        precompile_args.try_to_vec().unwrap(),
+                        borsh::to_vec(&precompile_args).unwrap(),
                     )
                     .await?;
                 println!("{result:?}");
@@ -427,7 +427,7 @@ pub async fn execute_command(
                 };
                 let storage = {
                     let result = client
-                        .view_call("get_storage_at", input.try_to_vec()?)
+                        .view_call("get_storage_at", borsh::to_vec(&input)?)
                         .await?;
                     H256::from_slice(&result.result)
                 };
@@ -485,7 +485,7 @@ pub async fn execute_command(
                 let next_nonce = deploy_response.transaction.nonce + 1;
 
                 let new_response = client
-                    .contract_call_with_nonce("new", new_args.try_to_vec()?, next_nonce)
+                    .contract_call_with_nonce("new", borsh::to_vec(&new_args)?, next_nonce)
                     .await?;
                 assert_tx_success(&new_response);
                 let next_nonce = new_response.transaction.nonce + 1;
@@ -493,7 +493,7 @@ pub async fn execute_command(
                 let init_response = client
                     .contract_call_with_nonce(
                         "new_eth_connector",
-                        init_args.try_to_vec().unwrap(),
+                        borsh::to_vec(&init_args).unwrap(),
                         next_nonce,
                     )
                     .await?;
@@ -529,7 +529,7 @@ pub async fn execute_command(
                         &sk,
                         Some(aurora_engine_precompiles::xcc::cross_contract_call::ADDRESS),
                         Wei::zero(),
-                        precompile_args.try_to_vec().unwrap(),
+                        borsh::to_vec(&precompile_args).unwrap(),
                     )
                     .await?;
                 println!("{result:?}");
@@ -604,7 +604,7 @@ pub async fn execute_command(
             }
             WriteCommand::DeployERC20Token { nep141 } => {
                 let nep141: AccountId = nep141.parse().unwrap();
-                let input = DeployErc20TokenArgs { nep141 }.try_to_vec()?;
+                let input = borsh::to_vec(&DeployErc20TokenArgs { nep141 })?;
                 let tx_outcome = client.contract_call("deploy_erc20_token", input).await?;
                 println!("{tx_outcome:?}");
             }
@@ -615,10 +615,9 @@ pub async fn execute_command(
                 println!("{tx_outcome:?}");
             }
             WriteCommand::SetPausedFlags { paused_mask } => {
-                let input = PauseEthConnectorCallArgs {
+                let input = borsh::to_vec(&PauseEthConnectorCallArgs {
                     paused_mask: u8::from_str(&paused_mask).unwrap(),
-                }
-                .try_to_vec()?;
+                })?;
                 let tx_outcome = client.contract_call("set_paused_flags", input).await?;
                 println!("{tx_outcome:?}");
             }

--- a/src/cli/simple/command/mod.rs
+++ b/src/cli/simple/command/mod.rs
@@ -3,13 +3,13 @@ use std::{path::Path, str::FromStr};
 
 use aurora_engine_sdk::types::near_account_to_evm_address;
 use aurora_engine_types::account_id::AccountId;
-use aurora_engine_types::borsh::{BorshDeserialize, BorshSerialize};
+use aurora_engine_types::borsh::BorshDeserialize;
 use aurora_engine_types::parameters::connector::{
-    Erc20Identifier, Erc20Metadata, InitCallArgs, MirrorErc20TokenArgs, SetErc20MetadataArgs,
-    SetEthConnectorContractAccountArgs, WithdrawSerializeType,
+    Erc20Identifier, Erc20Metadata, InitCallArgs, MirrorErc20TokenArgs, PauseEthConnectorCallArgs,
+    PausedMask, SetErc20MetadataArgs, SetEthConnectorContractAccountArgs, WithdrawSerializeType,
 };
 use aurora_engine_types::parameters::engine::{
-    GetStorageAtArgs, NewCallArgs, NewCallArgsV2, PausePrecompilesCallArgs, RelayerKeyArgs,
+    GetStorageAtArgs, LegacyNewCallArgs, PausePrecompilesCallArgs, RelayerKeyArgs,
     RelayerKeyManagerArgs, SetOwnerArgs, SetUpgradeDelayBlocksArgs, SubmitResult,
     TransactionStatus,
 };
@@ -94,6 +94,11 @@ pub async fn get_block_hash(context: Context, height: u64) -> anyhow::Result<()>
     get_value::<HexString>(context, "get_block_hash", Some(height)).await
 }
 
+/// Return an external ETH connector account id.
+pub async fn get_eth_connector_contract_account(context: Context) -> anyhow::Result<()> {
+    get_value::<String>(context, "get_eth_connector_contract_account", None).await
+}
+
 /// Deploy Aurora EVM smart contract.
 pub async fn deploy_aurora<P: AsRef<Path> + Send>(context: Context, path: P) -> anyhow::Result<()> {
     let code = std::fs::read(path)?;
@@ -125,14 +130,14 @@ pub async fn init(
     let owner_id = to_account_id(owner_id, &context)?;
     let prover_id = to_account_id(bridge_prover, &context)?;
 
-    let aurora_init_args = NewCallArgs::V2(NewCallArgsV2 {
+    let aurora_init_args = borsh::to_vec(&LegacyNewCallArgs {
         chain_id: H256::from_low_u64_be(chain_id).into(),
         owner_id,
+        bridge_prover_id: prover_id.clone(),
         upgrade_delay_blocks: upgrade_delay_blocks.unwrap_or_default(),
-    })
-    .try_to_vec()?;
+    })?;
 
-    let eth_connector_init_args = InitCallArgs {
+    let eth_connector_init_args = borsh::to_vec(&InitCallArgs {
         prover_account: prover_id,
         eth_custodian_address: custodian_address.map_or_else(
             || Address::default().encode(),
@@ -141,8 +146,7 @@ pub async fn init(
         metadata: utils::ft_metadata::parse_ft_metadata(
             ft_metadata_path.and_then(|path| std::fs::read_to_string(path).ok()),
         )?,
-    }
-    .try_to_vec()?;
+    })?;
 
     let batch = vec![
         ("new".to_string(), aurora_init_args),
@@ -420,13 +424,12 @@ pub async fn fund_xcc_sub_account(
     account_id: Option<String>,
     deposit: f64,
 ) -> anyhow::Result<()> {
-    let args = FundXccArgs {
+    let args = borsh::to_vec(&FundXccArgs {
         target: hex_to_address(&target)?,
         wnear_account_id: account_id
             .map(|id| id.parse().map_err(|e| anyhow::anyhow!("{e}")))
             .transpose()?,
-    }
-    .try_to_vec()?;
+    })?;
 
     contract_call!(
         "fund_xcc_sub_account",
@@ -439,10 +442,9 @@ pub async fn fund_xcc_sub_account(
 
 /// Set a new owner of the Aurora EVM.
 pub async fn set_owner(context: Context, account_id: String) -> anyhow::Result<()> {
-    let args = SetOwnerArgs {
+    let args = borsh::to_vec(&SetOwnerArgs {
         new_owner: account_id.parse().map_err(|e| anyhow::anyhow!("{e}"))?,
-    }
-    .try_to_vec()?;
+    })?;
 
     contract_call!(
         "set_owner",
@@ -470,11 +472,10 @@ pub async fn register_relayer(context: Context, address: String) -> anyhow::Resu
 pub async fn get_storage_at(context: Context, address: String, key: String) -> anyhow::Result<()> {
     let address = hex_to_address(&address)?;
     let key = H256::from_str(&key)?;
-    let input = GetStorageAtArgs {
+    let input = borsh::to_vec(&GetStorageAtArgs {
         address,
         key: key.0,
-    }
-    .try_to_vec()?;
+    })?;
 
     get_value::<H256>(context, "get_storage_at", Some(input)).await
 }
@@ -519,7 +520,7 @@ pub fn gen_near_key(account_id: &str, key_type: KeyType) -> anyhow::Result<()> {
 
 /// Pause precompiles with mask.
 pub async fn pause_precompiles(context: Context, mask: u32) -> anyhow::Result<()> {
-    let args = PausePrecompilesCallArgs { paused_mask: mask }.try_to_vec()?;
+    let args = borsh::to_vec(&PausePrecompilesCallArgs { paused_mask: mask })?;
 
     contract_call!(
         "pause_precompiles",
@@ -532,7 +533,7 @@ pub async fn pause_precompiles(context: Context, mask: u32) -> anyhow::Result<()
 
 /// Resume precompiles with mask.
 pub async fn resume_precompiles(context: Context, mask: u32) -> anyhow::Result<()> {
-    let args = PausePrecompilesCallArgs { paused_mask: mask }.try_to_vec()?;
+    let args = borsh::to_vec(&PausePrecompilesCallArgs { paused_mask: mask })?;
 
     contract_call!(
         "resume_precompiles",
@@ -546,6 +547,24 @@ pub async fn resume_precompiles(context: Context, mask: u32) -> anyhow::Result<(
 /// Return paused precompiles.
 pub async fn paused_precompiles(context: Context) -> anyhow::Result<()> {
     get_value::<u32>(context, "paused_precompiles", None).await
+}
+
+/// Set the paused mask for ETH connector.
+pub async fn set_paused_flags(context: Context, paused_mask: PausedMask) -> anyhow::Result<()> {
+    let args = borsh::to_vec(&PauseEthConnectorCallArgs { paused_mask })?;
+
+    contract_call!(
+        "set_paused_flags",
+        "The pause mask has been set successfully",
+        "Error while setting pause mask"
+    )
+    .proceed(context, args)
+    .await
+}
+
+/// Return the paused mask for ETH connector.
+pub async fn get_paused_flags(context: Context) -> anyhow::Result<()> {
+    get_value::<PausedMask>(context, "get_paused_flags", None).await
 }
 
 /// Set relayer key manager.
@@ -600,10 +619,9 @@ pub async fn remove_relayer_key(context: Context, public_key: PublicKey) -> anyh
 
 /// Set a delay in blocks for an upgrade.
 pub async fn set_upgrade_delay_blocks(context: Context, blocks: u64) -> anyhow::Result<()> {
-    let args = SetUpgradeDelayBlocksArgs {
+    let args = borsh::to_vec(&SetUpgradeDelayBlocksArgs {
         upgrade_delay_blocks: blocks,
-    }
-    .try_to_vec()?;
+    })?;
 
     contract_call!(
         "set_upgrade_delay_blocks",
@@ -616,7 +634,7 @@ pub async fn set_upgrade_delay_blocks(context: Context, blocks: u64) -> anyhow::
 
 /// Get ERC-20 address from account id of NEP-141.
 pub async fn get_erc20_from_nep141(context: Context, account_id: String) -> anyhow::Result<()> {
-    let args = account_id.try_to_vec()?;
+    let args = borsh::to_vec(&account_id)?;
     get_value::<HexString>(context, "get_erc20_from_nep141", Some(args)).await
 }
 
@@ -676,11 +694,10 @@ pub async fn mirror_erc20_token(
     contract_id: String,
     nep141: String,
 ) -> anyhow::Result<()> {
-    let args = MirrorErc20TokenArgs {
+    let args = borsh::to_vec(&MirrorErc20TokenArgs {
         contract_id: contract_id.parse().map_err(|e| anyhow::anyhow!("{e}"))?,
         nep141: nep141.parse().map_err(|e| anyhow::anyhow!("{e}"))?,
-    }
-    .try_to_vec()?;
+    })?;
 
     contract_call!(
         "mirror_erc20_token",
@@ -692,19 +709,18 @@ pub async fn mirror_erc20_token(
 }
 
 /// Set ETH connector account id
-pub async fn set_eth_connector_account_id(
+pub async fn set_eth_connector_contract_account(
     context: Context,
     account_id: String,
     withdraw_ser: Option<WithdrawSerialization>,
 ) -> anyhow::Result<()> {
-    let args = SetEthConnectorContractAccountArgs {
+    let args = borsh::to_vec(&SetEthConnectorContractAccountArgs {
         account: account_id.parse().map_err(|e| anyhow::anyhow!("{e}"))?,
         withdraw_serialize_type: withdraw_ser.map_or(WithdrawSerializeType::Borsh, |s| match s {
             WithdrawSerialization::Borsh => WithdrawSerializeType::Borsh,
             WithdrawSerialization::Json => WithdrawSerializeType::Json,
         }),
-    }
-    .try_to_vec()?;
+    })?;
 
     contract_call!(
         "set_eth_connector_contract_account",
@@ -722,14 +738,13 @@ pub async fn set_eth_connector_contract_data<P: AsRef<Path> + Send>(
     custodian_address: String,
     ft_metadata_path: P,
 ) -> anyhow::Result<()> {
-    let args = InitCallArgs {
+    let args = borsh::to_vec(&InitCallArgs {
         prover_account: prover_id.parse().map_err(|e| anyhow::anyhow!("{e}"))?,
         eth_custodian_address: custodian_address.trim_start_matches("0x").to_string(),
         metadata: utils::ft_metadata::parse_ft_metadata(
             std::fs::read_to_string(ft_metadata_path).ok(),
         )?,
-    }
-    .try_to_vec()?;
+    })?;
 
     contract_call!(
         "set_eth_connector_contract_data",
@@ -831,6 +846,12 @@ impl FromCallResult for HexString {
 impl FromCallResult for AccountId {
     fn from_result(result: CallResult) -> anyhow::Result<Self> {
         Self::try_from(result.result).map_err(|e| anyhow::anyhow!("{e}"))
+    }
+}
+
+impl FromCallResult for PausedMask {
+    fn from_result(result: CallResult) -> anyhow::Result<Self> {
+        Self::try_from_slice(&result.result).map_err(|e| anyhow::anyhow!("{e}"))
     }
 }
 

--- a/src/cli/simple/mod.rs
+++ b/src/cli/simple/mod.rs
@@ -327,7 +327,7 @@ pub enum Command {
         nep141: String,
     },
     /// Set eth connector account id
-    SetEthConnectorAccountId {
+    SetEthConnectorContractAccount {
         /// Account id of eth connector
         #[arg(long)]
         account_id: String,
@@ -335,6 +335,8 @@ pub enum Command {
         #[arg(long)]
         withdraw_ser: Option<WithdrawSerialization>,
     },
+    /// Get eth connector account id
+    GetEthConnectorContractAccount,
     /// Set eth connector data
     SetEthConnectorContractData {
         /// Prover account id
@@ -347,6 +349,13 @@ pub enum Command {
         #[arg(long)]
         ft_metadata_path: String,
     },
+    /// Set eth connector paused flags
+    SetPausedFlags {
+        /// Pause mask
+        mask: u8,
+    },
+    /// Get eth connector paused flags
+    GetPausedFlags,
 }
 
 #[derive(Clone)]
@@ -581,11 +590,14 @@ pub async fn run(args: Cli) -> anyhow::Result<()> {
         } => {
             command::mirror_erc20_token(context, contract_id, nep141).await?;
         }
-        Command::SetEthConnectorAccountId {
+        Command::SetEthConnectorContractAccount {
             account_id,
             withdraw_ser,
         } => {
-            command::set_eth_connector_account_id(context, account_id, withdraw_ser).await?;
+            command::set_eth_connector_contract_account(context, account_id, withdraw_ser).await?;
+        }
+        Command::GetEthConnectorContractAccount => {
+            command::get_eth_connector_contract_account(context).await?;
         }
         Command::SetEthConnectorContractData {
             prover_id,
@@ -599,6 +611,12 @@ pub async fn run(args: Cli) -> anyhow::Result<()> {
                 ft_metadata_path,
             )
             .await?;
+        }
+        Command::SetPausedFlags { mask } => {
+            command::set_paused_flags(context, mask).await?;
+        }
+        Command::GetPausedFlags => {
+            command::get_paused_flags(context).await?;
         }
     }
 

--- a/src/client/near.rs
+++ b/src/client/near.rs
@@ -1,4 +1,4 @@
-use aurora_engine_types::borsh::{BorshDeserialize, BorshSerialize};
+use aurora_engine_types::borsh::BorshDeserialize;
 #[cfg(feature = "advanced")]
 use aurora_engine_types::parameters::engine::SubmitResult;
 use aurora_engine_types::parameters::engine::TransactionStatus;
@@ -113,7 +113,7 @@ impl NearClient {
             nep141: nep141.parse().unwrap(),
         };
         let result = self
-            .view_call("get_erc20_from_nep141", args.try_to_vec()?)
+            .view_call("get_erc20_from_nep141", borsh::to_vec(&args)?)
             .await?;
 
         Address::try_from_slice(&result.result).map_err(|e| anyhow::anyhow!(e))
@@ -138,7 +138,7 @@ impl NearClient {
             amount: amount.to_bytes(),
             input,
         };
-        let result = self.view_call("view", args.try_to_vec()?).await?;
+        let result = self.view_call("view", borsh::to_vec(&args)?).await?;
         let status = TransactionStatus::try_from_slice(&result.result)?;
         Ok(status)
     }


### PR DESCRIPTION
The PR adds support to the following transactions:
- `get_eth_connector_contract_account`
- `set_eth_connector_contract_account`
- `get_paused_flags`
- `set_paused_flags`
- update dependencies and README.md