### PR TITLE
feat: derive Clone for NearClient struct

### DIFF
--- a/src/client/near.rs
+++ b/src/client/near.rs
@@ -42,6 +42,7 @@ use crate::utils;
 const NEAR_GAS: u64 = 300_000_000_000_000;
 const TIMEOUT: Duration = Duration::from_secs(20);
 
+#[derive(Clone)]
 pub struct NearClient {
     client: JsonRpcClient,
     pub engine_account_id: AccountId,


### PR DESCRIPTION
This PR adds `Clone` implementation for `NearClient` struct. 