### PR TITLE
feat: optimize nonce retrieval in NearClient

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -10,7 +10,9 @@ on:
 jobs:
   shell_tests:
     name: Tests ${{ matrix.interface }} CLI
-    runs-on: [ self-hosted, heavy ]
+    runs-on: selfhosted-heavy
+    container:
+      image: rust:latest
     strategy:
       matrix:
         interface: [ Advanced, Simple, Silo ]
@@ -27,10 +29,10 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-      - name: Install python-venv
+      - name: Install dependencies
         run: |
           apt update
-          apt -y install python3-venv
+          apt install -y jq python3-venv
       - name: Install aurora-cli
         uses: actions-rs/cargo@v1
         with:

--- a/src/client/near.rs
+++ b/src/client/near.rs
@@ -492,10 +492,7 @@ impl NearClient {
 
     pub async fn get_nonce(&self, signer: &InMemorySigner) -> anyhow::Result<(CryptoHash, u64)> {
         let nonces = self.access_key_nonces.read().await;
-        let cache_key = (
-            signer.account_id.clone(),
-            signer.secret_key.public_key().into(),
-        );
+        let cache_key = (signer.account_id.clone(), signer.secret_key.public_key());
 
         if let Some(nonce) = nonces.get(&cache_key) {
             let nonce = nonce.fetch_add(1, Ordering::SeqCst);
@@ -520,9 +517,9 @@ impl NearClient {
             let response = self.client.call(request).await?;
 
             let block_hash = response.block_hash;
-            let access_key = match response.kind {
-                QueryResponseKind::AccessKey(k) => k,
-                _ => anyhow::bail!("Wrong response kind: {:?}", response.kind),
+
+            let QueryResponseKind::AccessKey(access_key) = response.kind else {
+                anyhow::bail!("Wrong response kind: {:?}", response.kind)
             };
 
             // case where multiple writers end up at the same lock acquisition point and tries


### PR DESCRIPTION
This PR adds nonce cache to near::Client.
Internally caches the nonce as to not need to query for it every time, and ending up having to run into contention with others.