### PR TITLE
feat: add methods to configure engine account ID and signer in NearClient

### DIFF
--- a/src/cli/simple/command/mod.rs
+++ b/src/cli/simple/command/mod.rs
@@ -1085,11 +1085,11 @@ pub async fn add_relayer(
     full_access_pub_key: near_crypto::PublicKey,
     function_call_pub_key: near_crypto::PublicKey,
 ) -> anyhow::Result<()> {
-    let mut client = context.client.near();
+    let client = context.client.near();
     let account_id = client.engine_account_id.clone();
     let relayer_id = format!("relay.{}", client.engine_account_id);
 
-    client.engine_account_id = relayer_id.parse()?;
+    let client = client.with_engine_account_id(&relayer_id.parse()?);
 
     let rsp = client
         .add_relayer(

--- a/src/client/near.rs
+++ b/src/client/near.rs
@@ -618,4 +618,21 @@ impl NearClient {
             .await?;
         Ok(rsp)
     }
+
+    #[cfg(feature = "simple")]
+    pub fn with_engine_account_id(self, account_id: &AccountId) -> Self {
+        Self {
+            engine_account_id: account_id.to_owned(),
+            ..self
+        }
+    }
+
+    #[cfg(feature = "simple")]
+    #[allow(dead_code)]
+    pub fn with_signer(self, signer_key_path: Option<String>) -> Self {
+        Self {
+            signer_key_path,
+            ..self
+        }
+    }
 }


### PR DESCRIPTION
This PR adds builder-style methods for `engine_account_id` and `signer` fields in NearClient.