### PR TITLE
feat: DeployERC20 contract method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,7 @@ dependencies = [
  "anyhow",
  "aurora-engine-types",
  "borsh 1.5.7",
+ "hex",
  "near-contract-standards",
  "near-crypto",
  "near-gas",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -25,6 +25,7 @@ near-jsonrpc-client.workspace = true
 near-jsonrpc-primitives.workspace = true
 regex.workspace = true
 thiserror.workspace = true
+hex.workspace = true
 
 [dev-dependencies]
 near-contract-standards.workspace = true

--- a/sdk/src/aurora/common.rs
+++ b/sdk/src/aurora/common.rs
@@ -1,4 +1,4 @@
-use aurora_engine_types::account_id::AccountId;
+use aurora_engine_types::{account_id::AccountId, types::Address};
 
 pub trait IntoAurora<T> {
     fn into_aurora(self) -> T;
@@ -8,4 +8,16 @@ impl IntoAurora<AccountId> for crate::near::primitives::types::AccountId {
     fn into_aurora(self) -> AccountId {
         AccountId::new(self.as_ref()).unwrap()
     }
+}
+
+pub fn hex_to_arr<const SIZE: usize>(hex: &str) -> anyhow::Result<[u8; SIZE]> {
+    let mut output = [0u8; SIZE];
+
+    hex::decode_to_slice(hex.trim_start_matches("0x"), &mut output)
+        .map(|()| output)
+        .map_err(|e| anyhow::anyhow!("Couldn't create array from the hex: {hex}, {e}"))
+}
+
+pub fn hex_to_address(h: &str) -> anyhow::Result<Address> {
+    hex_to_arr(h).map(Address::from_array)
 }

--- a/sdk/src/aurora/contract/mod.rs
+++ b/sdk/src/aurora/contract/mod.rs
@@ -4,8 +4,8 @@ use near_primitives::types::AccountId;
 
 use super::{ContractMethodResponse, error::Error};
 
-mod read;
-mod write;
+pub mod read;
+pub mod write;
 
 impl ContractMethodResponse for () {
     fn parse(_rsp: Vec<u8>) -> Result<Self, Error> {

--- a/sdk/src/aurora/contract/write.rs
+++ b/sdk/src/aurora/contract/write.rs
@@ -181,3 +181,18 @@ impl ContractMethod for DeployERC20 {
             .map_err(Into::into)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::aurora::{ContractMethod, common, contract::write::DeployERC20};
+
+    #[test]
+    fn test_erc20_deploy_success() -> anyhow::Result<()> {
+        let addr = common::hex_to_address("0xdAC17F958D2ee523a2206206994597C13D831ec7")
+            .map_err(|_| anyhow::anyhow!("Failed to decode address"))?;
+        let borsh_addr_bytes = borsh::to_vec(&addr.as_bytes())?;
+
+        assert_eq!(addr, DeployERC20::parse_response(borsh_addr_bytes)?);
+        Ok(())
+    }
+}

--- a/sdk/src/aurora/contract/write.rs
+++ b/sdk/src/aurora/contract/write.rs
@@ -1,4 +1,5 @@
-use crate::aurora::{ContractMethod, error::Error};
+use std::io;
+
 use aurora_engine_types::{
     parameters::{
         connector::{MirrorErc20TokenArgs, SetEthConnectorContractAccountArgs},
@@ -7,7 +8,8 @@ use aurora_engine_types::{
     },
     types::Address,
 };
-use std::io;
+
+use crate::aurora::{ContractMethod, error::Error};
 
 pub struct SetEthConnectorContractAccount {
     pub args: SetEthConnectorContractAccountArgs,


### PR DESCRIPTION
This pull request introduces changes to the `sdk` module of the Aurora project, focusing on improving modularity and adding support for deploying ERC-20 tokens. The most important changes include making the `read` and `write` modules public, reworking imports for better organization, and implementing a new contract method for deploying ERC-20 tokens.

### Improvements to module visibility:

* [`sdk/src/aurora/contract/mod.rs`](diffhunk://#diff-a8bd2fa30a320cf07545a4f7fa0975feddbd0263bf11b5cd56b2d0602e53b791L7-R8): Changed the visibility of the `read` and `write` modules from private to public, allowing them to be accessed externally.

### Reorganization of imports:

* [`sdk/src/aurora/contract/write.rs`](diffhunk://#diff-ce28617d3a08b4385c7b555a2e5778b78964e3488c8f3e7979ed076c0396470fL1-R10): Consolidated and reorganized imports to improve readability and maintainability, grouping related items and reducing redundancy.

### New feature: Deploy ERC-20 tokens:

* [`sdk/src/aurora/contract/write.rs`](diffhunk://#diff-ce28617d3a08b4385c7b555a2e5778b78964e3488c8f3e7979ed076c0396470fR157-R181): Added a new struct `DeployERC20` and implemented the `ContractMethod` trait for it. This enables the deployment of ERC-20 tokens by defining the method name, parameters, and response parsing logic.