### PR TITLE
feat: add block number parameter for view methods

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt update
-          apt install -y jq python3-venv
+          apt install -y bash jq python3-venv
       - name: Install aurora-cli
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -10,9 +10,8 @@ on:
 jobs:
   shell_tests:
     name: Tests ${{ matrix.interface }} CLI
-    runs-on: selfhosted-heavy
-    container:
-      image: rust:latest
+    runs-on: k8s-infrastructure-native
+    container: rust:latest
     strategy:
       matrix:
         interface: [ Advanced, Simple, Silo ]

--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ Commands:
 
 Options:
       --network <NETWORK>              NEAR network ID [default: localnet]
+      --block-number <BLOCK_NUMBER>    Block number to use for the view command
       --engine <ACCOUNT_ID>            Aurora EVM account [default: aurora]
       --near-key-path <NEAR_KEY_PATH>  Path to file with NEAR account id and secret key in JSON format
   -h, --help                           Print help

--- a/cli/src/cli/mod.rs
+++ b/cli/src/cli/mod.rs
@@ -10,8 +10,8 @@ pub use advanced::{Cli, run};
 pub use simple::{Cli, command, run};
 
 /// NEAR Endpoints.
-const NEAR_MAINNET_ENDPOINT: &str = "https://rpc.mainnet.near.org/";
-const NEAR_TESTNET_ENDPOINT: &str = "https://rpc.testnet.near.org/";
+const NEAR_MAINNET_ENDPOINT: &str = "https://archival-rpc.mainnet.near.org/";
+const NEAR_TESTNET_ENDPOINT: &str = "https://archival-rpc.testnet.near.org/";
 #[cfg(feature = "simple")]
 const NEAR_LOCAL_ENDPOINT: &str = "http://127.0.0.1:3030/";
 /// Aurora Endpoints.

--- a/cli/src/cli/simple/command/mod.rs
+++ b/cli/src/cli/simple/command/mod.rs
@@ -878,7 +878,7 @@ pub async fn transaction_status(
         .transaction_status(tx_hash, wait_until.into())
         .await?;
 
-    println!("{}", serde_json::to_string_pretty(&rsp)?);
+    println!("{}", to_string_pretty(&rsp)?);
 
     Ok(())
 }
@@ -891,7 +891,7 @@ async fn get_value<T: FromCallResult + Display>(
     let result = context
         .client
         .near()
-        .view_call(method_name, args.unwrap_or_default())
+        .view_call_for_block(method_name, args.unwrap_or_default(), context.block_number)
         .await?;
     let output = T::from_result(result)?;
     println!("{output}");

--- a/cli/src/cli/simple/mod.rs
+++ b/cli/src/cli/simple/mod.rs
@@ -36,6 +36,9 @@ pub struct Cli {
     /// Path to file with NEAR account id and secret key in JSON format
     #[arg(long)]
     pub near_key_path: Option<String>,
+    /// NEAR block number to use for getting data
+    #[arg(long)]
+    pub block_number: Option<u64>,
     #[clap(subcommand)]
     pub command: Command,
 }
@@ -465,7 +468,7 @@ pub async fn run(args: Cli) -> anyhow::Result<()> {
         Network::Localnet => super::NEAR_LOCAL_ENDPOINT,
     };
     let client = crate::client::Client::new(near_rpc, &args.engine, args.near_key_path);
-    let context = crate::client::Context::new(client, args.output_format);
+    let context = crate::client::Context::new(client, args.output_format, args.block_number);
 
     match args.command {
         Command::GetChainId => command::get_chain_id(context).await?,

--- a/cli/src/client/mod.rs
+++ b/cli/src/client/mod.rs
@@ -30,14 +30,20 @@ type NearCallError = near_jsonrpc_client::errors::JsonRpcError<
 pub struct Context {
     pub client: Client,
     pub output_format: OutputFormat,
+    pub block_number: Option<u64>,
 }
 
 #[cfg(feature = "simple")]
 impl Context {
-    pub const fn new(client: Client, output_format: OutputFormat) -> Self {
+    pub const fn new(
+        client: Client,
+        output_format: OutputFormat,
+        block_number: Option<u64>,
+    ) -> Self {
         Self {
             client,
             output_format,
+            block_number,
         }
     }
 }

--- a/cli/src/client/near.rs
+++ b/cli/src/client/near.rs
@@ -170,8 +170,24 @@ impl NearClient {
         method_name: &str,
         args: Vec<u8>,
     ) -> anyhow::Result<views::CallResult> {
+        self.view_call_for_block(method_name, args, None).await
+    }
+
+    pub async fn view_call_for_block(
+        &self,
+        method_name: &str,
+        args: Vec<u8>,
+        block_number: Option<u64>,
+    ) -> anyhow::Result<views::CallResult> {
+        let block_reference = block_number.map_or_else(
+            || Finality::Final.into(),
+            |block_number| {
+                BlockReference::BlockId(near_primitives::types::BlockId::Height(block_number))
+            },
+        );
+
         let request = methods::query::RpcQueryRequest {
-            block_reference: Finality::Final.into(),
+            block_reference,
             request: views::QueryRequest::CallFunction {
                 account_id: self.engine_account_id.clone(),
                 method_name: method_name.to_string(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a NEAR block number when using the `view` command via a new global CLI option `--block-number <BLOCK_NUMBER>`.
* **Documentation**
  * Updated the README to document the new `--block-number` option for the CLI.
* **Enhancements**
  * Improved NEAR network reliability by switching to archival RPC endpoints for both mainnet and testnet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->